### PR TITLE
Add a note to the `Slack App Route` doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,20 +5,20 @@ Send data into Slack using this GitHub Action! This package has two different te
 1) Send data to Slack's Workflow Builder (requires a paid Slack instance).
 2) Send data via a Slack app to post to a specific channel (use an existing custom app or create a new one).
 
-The recommended way to use this action is with Slack's Workflow Builder (if you're on a paid Slack plan). 
+The recommended way to use this action is with Slack's Workflow Builder (if you're on a paid Slack plan).
 
 ## Slack Workflow Builder Route
 
-Sending data to [Slack's Workflow builder](https://slack.com/intl/en-ca/features/workflow-automation) is the recommended way to use this action. This action will send data into Slack via a webhook URL. Follow [these steps to create a Slack workflow using webhooks](https://slack.com/intl/en-ca/help/articles/360041352714-Create-more-advanced-workflows-using-webhooks). The Slack workflow webhook url will be in the form of `https://hooks.slack.com/workflows/....`. The payload sent by this GitHub action will be flattened (all nested keys moved top level) and stringified since Slack's workflow builder only supports top level string values in payloads. 
+Sending data to [Slack's Workflow builder](https://slack.com/intl/en-ca/features/workflow-automation) is the recommended way to use this action. This action will send data into Slack via a webhook URL. Follow [these steps to create a Slack workflow using webhooks](https://slack.com/intl/en-ca/help/articles/360041352714-Create-more-advanced-workflows-using-webhooks). The Slack workflow webhook url will be in the form of `https://hooks.slack.com/workflows/....`. The payload sent by this GitHub action will be flattened (all nested keys moved top level) and stringified since Slack's workflow builder only supports top level string values in payloads.
 
-You need to define expected variables in the payload the webhook will receive. If these variables are missing in the payload, an error is returned. 
+You need to define expected variables in the payload the webhook will receive. If these variables are missing in the payload, an error is returned.
 
 ### Setup
 
 * [Create a Slack workflow webhook](https://slack.com/intl/en-ca/help/articles/360041352714-Create-more-advanced-workflows-using-webhooks)
 * Copy the webhook URL (`https://hooks.slack.com/workflows/....`) and [add it as a secret in your repo settings](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository) named `SLACK_WEBHOOK_URL`.
 * Add a step to your GitHub action to send data to your Webhook
-* Configure your Slack workflow to use variables from the incoming payload from the GitHub Action. You can select where you want to post the data and how you want to format it in Slack's worflow builder interface. 
+* Configure your Slack workflow to use variables from the incoming payload from the GitHub Action. You can select where you want to post the data and how you want to format it in Slack's worflow builder interface.
 
 ### Usage
 
@@ -44,13 +44,14 @@ or
 
 ## Slack App Route
 
-This route allows 
+This route allows
 
 ## Setup
 
 * [Create a slack app]() for your workspace (alternatively use an existing app you have already created and installed)
-  * Add the `chat.write` scope under **OAuth & Permissions**
+* Add the `chat.write` scope under **OAuth & Permissions**
 * Install the app to your workspace
+* Invite the bot user into the channel (`/invite @bot_user_name`)
 
 ### Usage
 


### PR DESCRIPTION
###  Summary

Add a note to the `Slack App Route` doc: one must add a bot user to the channel, otherwise all attempts to post a message will throw `not_in_channel` error.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).