### PR TITLE
docs: fix create slack app link

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This route allows
 
 ## Setup
 
-* [Create a slack app]() for your workspace (alternatively use an existing app you have already created and installed)
+* [Create a slack app](https://api.slack.com/apps) for your workspace (alternatively use an existing app you have already created and installed)
   * Add the `chat.write` scope under **OAuth & Permissions**
 * Install the app to your workspace
 


### PR DESCRIPTION
resolve #8

###  Summary

Added a link URL to the "create slack app" anchor.  
This resolves the Issues in #8.  


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).