### PR TITLE
README.md: fix typo in link name

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,4 +71,4 @@ See [CONTRIBUTING](.github/contributing.md).
 
 ## License
 
-See [LICENSNE](LICENSE).
+See [LICENSE](LICENSE).


### PR DESCRIPTION
###  Summary

Fix a small typo in the link to the license file.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).