### PR TITLE
Fix #18 - Enable passing JSON payload to Slack App Route

### DIFF
--- a/example-workflows/Bot token post to channel/JSONTextPayload.yml
+++ b/example-workflows/Bot token post to channel/JSONTextPayload.yml
@@ -1,0 +1,15 @@
+on: [push]
+
+jobs:
+  new_push_job:
+    runs-on: ubuntu-latest
+    name: New push to repo
+    steps:
+    - name: Send GitHub trigger payload to Slack Workflow Builder
+      id: slack
+      uses: slackapi/slack-github-action@v1.15.0
+      with:
+        channel-id: 'SLACK_CHANNEL_ID' # ID of Slack Channel you want to post to
+        payload: "{\"text\":\"posting from a github action\"}"
+      env:
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/example-workflows/Bot token post to channel/customJSONPayload.yml
+++ b/example-workflows/Bot token post to channel/customJSONPayload.yml
@@ -1,0 +1,47 @@
+on: [push]
+
+jobs:
+  new_push_job:
+    runs-on: ubuntu-latest
+    name: New push to repo
+    steps:
+    - name: Send GitHub trigger payload to Slack Workflow Builder
+      id: slack
+      uses: slackapi/slack-github-action@v1.15.0
+      with:
+        channel-id: 'SLACK_CHANNEL_ID' # ID of Slack Channel you want to post to
+        payload: |
+          {
+            "blocks": [
+              { "type": "divider" },
+              {
+                "type": "image",
+                "title": {
+                  "type": "plain_text",
+                  "text": "Slack Slack Slack",
+                  "emoji": true
+                },
+                "image_url": "https://media.makeameme.org/created/a-slack-this.jpg",
+                "alt_text": "marg"
+              },
+              {
+                "type": "actions",
+                "elements": [
+                  {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": $values.button_text
+                    },
+                    "url": $values.button_url
+                  }
+                ]
+              }
+            ],
+            channel-id": "NEW_TARGET_CHANNEL_ID"
+          }
+      env:
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      values: |
+        button_text: ${{ github.sha }}
+        button_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ try {
 
         if(channelId.length > 0 && (message.length > 0 || payload)) {
             // post message
-            web.chat.postMessage({channel: channelId, text: message, ...(payload ?? {})});
+            web.chat.postMessage({channel: channelId, text: message, ...(payload || {})});
         } else {
             console.log('missing either channel-id, slack-message or payload! Did not send a message via chat.postMessage with botToken');
         }


### PR DESCRIPTION
###  Summary

The goals of this PR is to enable BotToken users to leverage the payload to pass json to a bot and resolves #18 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).