### PR TITLE
Adding automated build & tag update on release

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,19 @@
+name: Publish
+
+on:
+  release:
+    types: [published, edited]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - name: Install deps and build
+        run: npm ci && npm run build
+      - uses: JasonEtco/build-and-tag-action@v2
+        env:
+          GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
###  Summary

As identified in https://github.com/slackapi/slack-github-action/issues/16, there are no automated builds or releases being done.  This added workflow will build on release and update the associated major/minor tracking tags - if you do a `v1.16.0` release; it will build, update the `dist/index.json` to a new commit, then update the release tag as well as the tracking tags `v1` and `v1.16` automatically.

It will still require someone manually making a new version release after a merge to master. This could further be automated to use a merge commit message.

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).