### PR TITLE
[#10] Disallow empty string for SLACK_BOT_TOKEN and SLACK_WEBHOOK_URL

### DIFF
--- a/src/slack-send.js
+++ b/src/slack-send.js
@@ -20,8 +20,8 @@ module.exports = async function slackSend(core) {
       webhookType = process.env.SLACK_WEBHOOK_TYPE.toUpperCase();
     }
 
-    if (botToken === undefined && webhookUrl === undefined) {
-      throw new Error('Need to provide at least one botToken or webhookUrl');
+    if ((botToken === undefined || botToken.length === 0) && (webhookUrl === undefined || webhookUrl.length === 0)) {
+      throw new Error('You must provide a valid, non-empty `SLACK_BOT_TOKEN` or `SLACK_WEBHOOK_URL`');
     }
 
     let payload = core.getInput('payload');

--- a/src/slack-send.js
+++ b/src/slack-send.js
@@ -20,13 +20,13 @@ module.exports = async function slackSend(core) {
       webhookType = process.env.SLACK_WEBHOOK_TYPE.toUpperCase();
     }
 
-    if ((botToken === undefined || botToken.length === 0) && (webhookUrl === undefined || webhookUrl.length === 0)) {
+    if ((typeof botToken === 'undefined' || botToken.length === 0) && (typeof webhookUrl === 'undefined' || webhookUrl.length === 0)) {
       throw new Error('You must provide a valid, non-empty `SLACK_BOT_TOKEN` or `SLACK_WEBHOOK_URL`');
     }
 
     let payload = core.getInput('payload');
 
-    if (payload) {
+    if (typeof payload !== 'undefined') {
       try {
         // confirm it is valid json
         payload = JSON.parse(payload);
@@ -38,8 +38,8 @@ module.exports = async function slackSend(core) {
     }
 
     if (typeof botToken !== 'undefined' && botToken.length > 0) {
-      const message = core.getInput('slack-message');
-      const channelId = core.getInput('channel-id');
+      const message = core.getInput('slack-message') || '';
+      const channelId = core.getInput('channel-id') || '';
       const web = new WebClient(botToken);
 
       if (channelId.length > 0 && (message.length > 0 || payload)) {
@@ -76,7 +76,6 @@ module.exports = async function slackSend(core) {
       } catch (err) {
         console.log('axios post failed, double check the payload being sent includes the keys Slack expects');
         console.log(payload);
-        // console.log(err);
 
         if (err.response) {
           core.setFailed(err.response.data);

--- a/test/slack-send-test.js
+++ b/test/slack-send-test.js
@@ -42,7 +42,14 @@ describe('slack-send', () => {
     delete process.env.SLACK_BOT_TOKEN;
     delete process.env.SLACK_WEBHOOK_URL;
     await slackSend(fakeCore);
-    assert.include(fakeCore.setFailed.lastCall.firstArg.message, 'Need to provide at least one botToken or webhook', 'Error set specifying what env vars need to be set.');
+    assert.include(fakeCore.setFailed.lastCall.firstArg.message, 'You must provide a valid, non-empty `SLACK_BOT_TOKEN` or `SLACK_WEBHOOK_URL`', 'Error set specifying what env vars need to be set.');
+  });
+
+  it('should set an error if webhook URL and token are empty strings', async () => {
+    process.env.SLACK_BOT_TOKEN = '';
+    process.env.SLACK_WEBHOOK_URL = '';
+    await slackSend(fakeCore);
+    assert.include(fakeCore.setFailed.lastCall.firstArg.message, 'You must provide a valid, non-empty `SLACK_BOT_TOKEN` or `SLACK_WEBHOOK_URL`', 'Error set specifying what env vars need to be set.');
   });
 
   describe('using a bot token', () => {


### PR DESCRIPTION
###  Summary

Fixes: https://github.com/slackapi/slack-github-action/issues/10

Fail quick if the `SLACK_BOT_TOKEN` or `SLACK_WEBHOOK_URL` are empty strings

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).