### PR TITLE
#73 added thread-ts as an output

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,19 @@ jobs:
     - name: Check Action output is not empty
       run: test -n "${{ steps.slackToken.outputs.time }}"
 
+    - name: Post Threaded Response
+      id: slackThreadResponse
+      uses: ./
+      with:
+        channel-id: ${{ secrets.SLACK_CHANNEL_ID }} 
+        payload: |
+            {
+              "text": "This message should be posted as a response in thread",
+              "thread_ts": "${{ steps.slackToken.outputs.thread_ts }}"
+            }
+      env:
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
   integration_test_webhook:
     runs-on: ubuntu-latest
     steps:

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,8 @@ inputs:
 outputs:
   time: # id of output
     description: 'The time'
+  thread_ts: # timestamp on the message that was posted when using bot token
+    description: 'The timestamp on the message that was posted into Slack when using bot token'
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/test/slack-send-test.js
+++ b/test/slack-send-test.js
@@ -5,7 +5,7 @@ const github = require('@actions/github');
 const rewiremock = require('rewiremock/node');
 
 const ChatStub = {
-  postMessage: sinon.spy(),
+  postMessage: sinon.fake.resolves({ ok: true, thread_ts: '1503435956.000247' }),
 };
 /* eslint-disable-next-line global-require */
 rewiremock(() => require('@slack/web-api')).with({
@@ -57,6 +57,8 @@ describe('slack-send', () => {
         fakeCore.getInput.withArgs('slack-message').returns('who let the dogs out?');
         fakeCore.getInput.withArgs('channel-id').returns('C123456');
         await slackSend(fakeCore);
+        assert.equal(fakeCore.setOutput.firstCall.firstArg, 'thread_ts', 'Output name set to thread_ts');
+        assert(fakeCore.setOutput.firstCall.lastArg.length > 0, 'Time output a non-zero-length string');
         assert.equal(fakeCore.setOutput.lastCall.firstArg, 'time', 'Output name set to time');
         assert(fakeCore.setOutput.lastCall.lastArg.length > 0, 'Time output a non-zero-length string');
         const chatArgs = ChatStub.postMessage.lastCall.firstArg;
@@ -74,6 +76,8 @@ describe('slack-send', () => {
         await slackSend(fakeCore);
 
         // Assert
+        assert.equal(fakeCore.setOutput.firstCall.firstArg, 'thread_ts', 'Output name set to thread_ts');
+        assert(fakeCore.setOutput.firstCall.lastArg.length > 0, 'Time output a non-zero-length string');
         assert.equal(fakeCore.setOutput.lastCall.firstArg, 'time', 'Output name set to time');
         assert(fakeCore.setOutput.lastCall.lastArg.length > 0, 'Time output a non-zero-length string');
         const chatArgs = ChatStub.postMessage.lastCall.firstArg;


### PR DESCRIPTION
###  Summary

Fixes #73 by adding `thread_ts` as an output when using a botToken. This is useful for threading.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).