### PR TITLE
Add support to update messages #75

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,57 @@ Using JSON payload for constructing a message is also available:
     SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 ```
 
+### Update the message
+
+Using `update-ts: ${{ steps.slack.outputs.ts }}` will update the message that was posted. 
+
+```yaml
+- id: slack
+  uses: slackapi/slack-github-action@v1.18.0
+  with:
+    channel-id: "#channel"
+    payload: |
+      {
+        "attachments": [
+          {
+            "pretext": "Deployment started",
+            "color": "dbab09",
+            "fields": [
+              {
+                "title": "Status",
+                "short": true,
+                "value": "In Progress"
+              }
+            ]
+          }
+        ]
+      }
+  env:
+    SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN}}
+- uses: slackapi/slack-github-action@v1.18.0
+  with:
+    channel-id: "#channel"
+    update-ts: ${{ steps.slack.outputs.ts }}
+    payload: |
+      {
+        "attachments": [
+          {
+            "pretext": "Deployment finished",
+            "color": "28a745",
+            "fields": [
+              {
+                "title": "Status",
+                "short": true,
+                "value": "Completed"
+              }
+            ]
+          }
+        ]
+      }
+  env:
+    SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN}}
+```
+
 ## Technique 3: Slack Incoming Webhook
 
 This approach allows your GitHub Actions job to post a message to a Slack channel or direct message by utilizing [Incoming Webhooks](https://api.slack.com/messaging/webhooks).

--- a/README.md
+++ b/README.md
@@ -124,17 +124,18 @@ Using JSON payload for constructing a message is also available:
     SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 ```
 
-### Update the message
+#### Update the message
 
-Using `update-ts: ${{ steps.slack.outputs.ts }}` will update the message that was posted. 
+If you would like to notify the real-time updates on a build status, you can modify the message your build job posted in the subsequent steps. In order to do this, the steps after the first message posting can have `update-ts: ${{ steps.slack.outputs.ts }}` in their settings. With this, the step updates the already posted channel message instead of posting a new one.
 
 ```yaml
 - id: slack
-  uses: slackapi/slack-github-action@v1.18.0
+  uses: slackapi/slack-github-action@v1.20.0
   with:
-    channel-id: "#channel"
+    channel-id: "CHANNEL_ID"
     payload: |
       {
+        "text": "Deployment started (In Progress)",
         "attachments": [
           {
             "pretext": "Deployment started",
@@ -151,12 +152,13 @@ Using `update-ts: ${{ steps.slack.outputs.ts }}` will update the message that wa
       }
   env:
     SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN}}
-- uses: slackapi/slack-github-action@v1.18.0
+- uses: slackapi/slack-github-action@v1.20.0
   with:
-    channel-id: "#channel"
+    channel-id: "CHANNEL_ID"
     update-ts: ${{ steps.slack.outputs.ts }}
     payload: |
       {
+        "text": "Deployment finished (Completed)",
         "attachments": [
           {
             "pretext": "Deployment finished",

--- a/src/slack-send.js
+++ b/src/slack-send.js
@@ -69,7 +69,7 @@ module.exports = async function slackSend(core) {
       }
 
       if (message.length > 0 || payload) {
-        const ts = core.getInput('update-ts')
+        const ts = core.getInput('update-ts');
         if (ts) {
           // update message
           webResponse = await web.chat.update({ ts, channel: channelId, text: message, ...(payload || {}) });


### PR DESCRIPTION
###  Summary

- [x] add test
- [x] add usage doc

#75 
- `outputs.time` was not what I need. Added `outputs.ts`
- added `update-ts` option which calls `chat.update` api 



```yml
- id: slack
  uses: slackapi/slack-github-action@v1.18.0
  with:
    channel-id: "#channel"
    payload: |
      {
        "attachments": [
          {
            "pretext": "Deployment started",
            "color": "dbab09",
            "fields": [
              {
                "title": "Status",
                "short": true,
                "value": "In Progress"
              }
            ]
          }
        ]
      }
  env:
    SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN}}
- uses: slackapi/slack-github-action@v1.18.0
  with:
    channel-id: "#channel"
    update-ts: ${{ steps.slack.outputs.ts }}
    payload: |
      {
        "attachments": [
          {
            "pretext": "Deployment finished",
            "color": "28a745",
            "fields": [
              {
                "title": "Status",
                "short": true,
                "value": "Completed"
              }
            ]
          }
        ]
      }
  env:
    SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN}}
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).