### PR TITLE
feat(message): support multiple channel IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,22 @@ Using JSON payload for constructing a message is also available:
     SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 ```
 
+Multiple channels can be sent the same message by providing a comma-separated list of ID's:
+
+```yaml
+- name: Post to a Slack channel
+  id: slack
+  uses: slackapi/slack-github-action@v1.21.0
+  with:
+    # Slack channel id, channel name, or user id to post message.
+    # See also: https://api.slack.com/methods/chat.postMessage#channels
+    channel-id: "CHANNEL_ID_123,CHANNEL_ID_987"
+    # For posting a simple plain text message
+    slack-message: "GitHub build result: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+  env:
+    SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+```
+
 #### Update the message
 
 If you would like to notify the real-time updates on a build status, you can modify the message your build job posted in the subsequent steps. In order to do this, the steps after the first message posting can have `update-ts: ${{ steps.slack.outputs.ts }}` in their settings. With this, the step updates the already posted channel message instead of posting a new one.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ Add this Action as a [step][job-step] to your project's GitHub Action Workflow f
   with:
     # Slack channel id, channel name, or user id to post message.
     # See also: https://api.slack.com/methods/chat.postMessage#channels
-    channel-id: 'CHANNEL_ID'
+    # You can pass in multiple channels to post to by providing a comma-delimited list of channel IDs.
+    channel-id: 'CHANNEL_ID,ANOTHER_CHANNEL_ID'
     # For posting a simple plain text message
     slack-message: "GitHub build result: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
   env:
@@ -120,22 +121,6 @@ Using JSON payload for constructing a message is also available:
           }
         ]
       }
-  env:
-    SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-```
-
-Multiple channels can be sent the same message by providing a comma-separated list of ID's:
-
-```yaml
-- name: Post to a Slack channel
-  id: slack
-  uses: slackapi/slack-github-action@v1.21.0
-  with:
-    # Slack channel id, channel name, or user id to post message.
-    # See also: https://api.slack.com/methods/chat.postMessage#channels
-    channel-id: "CHANNEL_ID_123,CHANNEL_ID_987"
-    # For posting a simple plain text message
-    slack-message: "GitHub build result: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
   env:
     SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 ```

--- a/test/slack-send-test.js
+++ b/test/slack-send-test.js
@@ -56,16 +56,19 @@ describe('slack-send', () => {
     describe('happy path', () => {
       it('should send a message using the postMessage API', async () => {
         fakeCore.getInput.withArgs('slack-message').returns('who let the dogs out?');
-        fakeCore.getInput.withArgs('channel-id').returns('C123456');
+        fakeCore.getInput.withArgs('channel-id').returns('C123456,C987654');
         await slackSend(fakeCore);
         assert.equal(fakeCore.setOutput.firstCall.firstArg, 'ts', 'Output name set to ts');
         assert.equal(fakeCore.setOutput.secondCall.firstArg, 'thread_ts', 'Output name set to thread_ts');
         assert(fakeCore.setOutput.secondCall.lastArg.length > 0, 'Time output a non-zero-length string');
         assert.equal(fakeCore.setOutput.lastCall.firstArg, 'time', 'Output name set to time');
         assert(fakeCore.setOutput.lastCall.lastArg.length > 0, 'Time output a non-zero-length string');
-        const chatArgs = ChatStub.postMessage.lastCall.firstArg;
-        assert.equal(chatArgs.channel, 'C123456', 'Correct channel provided to postMessage');
-        assert.equal(chatArgs.text, 'who let the dogs out?', 'Correct message provided to postMessage');
+        const firstChatArgs = ChatStub.postMessage.firstCall.firstArg;
+        const secondChatArgs = ChatStub.postMessage.lastCall.firstArg;
+        assert.oneOf('C123456', [firstChatArgs.channel, secondChatArgs.channel], 'First comma-separated channel provided to postMessage');
+        assert.oneOf('C987654', [firstChatArgs.channel, secondChatArgs.channel], 'Second comma-separated channel provided to postMessage');
+        assert.equal(firstChatArgs.text, 'who let the dogs out?', 'Correct message provided to postMessage with first comma-separated channel');
+        assert.equal(secondChatArgs.text, 'who let the dogs out?', 'Correct message provided to postMessage with second comma-separated channel');
       });
 
       it('should send a message using the update API', async () => {

--- a/test/slack-send-test.js
+++ b/test/slack-send-test.js
@@ -56,19 +56,16 @@ describe('slack-send', () => {
     describe('happy path', () => {
       it('should send a message using the postMessage API', async () => {
         fakeCore.getInput.withArgs('slack-message').returns('who let the dogs out?');
-        fakeCore.getInput.withArgs('channel-id').returns('C123456,C987654');
+        fakeCore.getInput.withArgs('channel-id').returns('C123456');
         await slackSend(fakeCore);
         assert.equal(fakeCore.setOutput.firstCall.firstArg, 'ts', 'Output name set to ts');
         assert.equal(fakeCore.setOutput.secondCall.firstArg, 'thread_ts', 'Output name set to thread_ts');
         assert(fakeCore.setOutput.secondCall.lastArg.length > 0, 'Time output a non-zero-length string');
         assert.equal(fakeCore.setOutput.lastCall.firstArg, 'time', 'Output name set to time');
         assert(fakeCore.setOutput.lastCall.lastArg.length > 0, 'Time output a non-zero-length string');
-        const firstChatArgs = ChatStub.postMessage.firstCall.firstArg;
-        const secondChatArgs = ChatStub.postMessage.lastCall.firstArg;
-        assert.oneOf('C123456', [firstChatArgs.channel, secondChatArgs.channel], 'First comma-separated channel provided to postMessage');
-        assert.oneOf('C987654', [firstChatArgs.channel, secondChatArgs.channel], 'Second comma-separated channel provided to postMessage');
-        assert.equal(firstChatArgs.text, 'who let the dogs out?', 'Correct message provided to postMessage with first comma-separated channel');
-        assert.equal(secondChatArgs.text, 'who let the dogs out?', 'Correct message provided to postMessage with second comma-separated channel');
+        const chatArgs = ChatStub.postMessage.lastCall.firstArg;
+        assert.equal(chatArgs.channel, 'C123456', 'Correct channel provided to postMessage');
+        assert.equal(chatArgs.text, 'who let the dogs out?', 'Correct message provided to postMessage');
       });
 
       it('should send a message using the update API', async () => {

--- a/test/slack-send-test.js
+++ b/test/slack-send-test.js
@@ -105,6 +105,18 @@ describe('slack-send', () => {
         assert.equal(chatArgs.oliver, 'benji', 'Correct message provided to postMessage');
         assert.equal(chatArgs.actor, 'user123', 'Correct message provided to postMessage');
       });
+
+      it('should send the same message to multiple channels', async () => {
+        fakeCore.getInput.withArgs('slack-message').returns('who let the dogs out?');
+        fakeCore.getInput.withArgs('channel-id').returns('C123456,C987654');
+        await slackSend(fakeCore);
+        const firstChatArgs = ChatStub.postMessage.firstCall.firstArg;
+        const secondChatArgs = ChatStub.postMessage.lastCall.firstArg;
+        assert.oneOf('C123456', [firstChatArgs.channel, secondChatArgs.channel], 'First comma-separated channel provided to postMessage');
+        assert.oneOf('C987654', [firstChatArgs.channel, secondChatArgs.channel], 'Second comma-separated channel provided to postMessage');
+        assert.equal(firstChatArgs.text, 'who let the dogs out?', 'Correct message provided to postMessage with first comma-separated channel');
+        assert.equal(secondChatArgs.text, 'who let the dogs out?', 'Correct message provided to postMessage with second comma-separated channel');
+      });
     });
     describe('sad path', () => {
       it('should set an error if payload cannot be JSON parsed', async () => {


### PR DESCRIPTION
###  Summary

Adds support for comma-separated channel ID's.

Closes #118 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
