### PR TITLE
Bump node from 12 to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,5 +24,5 @@ outputs:
   ts: # timestamp of message posted
     description: 'The timestamp on the message that was posted into Slack when using bot token'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "slack-github-action",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "slack-github-action",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.9.1",
@@ -30,8 +30,8 @@
         "sinon": "^14.0.0"
       },
       "engines": {
-        "node": ">=12.0.0",
-        "npm": ">=6.4.1"
+        "node": ">=16.0.0",
+        "npm": ">=8.15.0"
       }
     },
     "node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "url": "https://github.com/slackapi/slack-github-action/issues"
   },
   "engines": {
-    "node": ">=12.0.0",
-    "npm": ">=6.4.1"
+    "node": ">=16.0.0",
+    "npm": ">=8.15.0"
   },
   "homepage": "https://github.com/slackapi/slack-github-action#readme",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "engines": {
     "node": ">=16.0.0",
-    "npm": ">=8.15.0"
+    "npm": ">=7.10.0"
   },
   "homepage": "https://github.com/slackapi/slack-github-action#readme",
   "dependencies": {


### PR DESCRIPTION
###  Summary

Bumps node12 to node16. Also suggesting at least node 16 for install. Node 12 is EOL.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).