### PR TITLE
Add in testing instructions for maintainer's guide and standardize bullet point punctuation

### DIFF
--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -23,14 +23,14 @@ Actions jobs that execute what are effectively integration tests for this GitHub
   -  If all issues have been closed, continue with the release.
   -  If issues are still open, discuss with the team about whether the open issues should be moved to a future release or if the release should be held off until the issues are resolved.
   -  Take a look at all issues under the Milestone to make sure that the type of issues included aligns with the Milestone name based on [semantic versioning](https://semver.org/). If the issues do not align with the naming of the Milestone (ex: if the issues are all bug fixes, but the Milestone is labeled as a minor release), then you can tweak the Milestone name to reflect the correct versioning.
-* Update the version in `package.json`
-* Update all references to versions in the README and in the workflow files under `example-workflows/` to refer to the latest release
-* Run all tests using `npm test` to make sure everything looks good and the tests pass!
-* Commit the changes on your `main` branch
-* Create a git tag for the new version. Should be in the format `v1.4.0`. `git tag v1.4.0`
-* Push changes up to GitHub `git push origin main --tags`
+* Update the version in `package.json`.
+* Update all references to versions in the README and in the workflow files under `example-workflows/` to refer to the latest release.
+* Run all tests using `npm test` to make sure the tests pass.
+* Commit the changes on your `main` branch.
+* Create a git tag for the new version. Should be in the format `v1.4.0`. `git tag v1.4.0`.
+* Push changes up to GitHub `git push origin main --tags`.
 * Create a GitHub Release based on the tag you just pushed up - this will trigger the publishing
-  GitHub workflow
+  GitHub workflow.
 * Once released, make sure to close the relevant GitHub Milestone for the version you released.
 
 ## Workflow

--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -25,7 +25,8 @@ Actions jobs that execute what are effectively integration tests for this GitHub
   -  Take a look at all issues under the Milestone to make sure that the type of issues included aligns with the Milestone name based on [semantic versioning](https://semver.org/). If the issues do not align with the naming of the Milestone (ex: if the issues are all bug fixes, but the Milestone is labeled as a minor release), then you can tweak the Milestone name to reflect the correct versioning.
 * Update the version in `package.json`
 * Update all references to versions in the README and in the workflow files under `example-workflows/` to refer to the latest release
-* Commit the changes
+* Run all tests using `npm test` to make sure everything looks good and the tests pass!
+* Commit the changes on your `main` branch
 * Create a git tag for the new version. Should be in the format `v1.4.0`. `git tag v1.4.0`
 * Push changes up to GitHub `git push origin main --tags`
 * Create a GitHub Release based on the tag you just pushed up - this will trigger the publishing


### PR DESCRIPTION
###  Summary

Update maintainer's guide to include instructions on running testing before pushing up commits directly to `main`. Also standardized bullet point punctuation in the maintainer's guide.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).