### PR TITLE
Add channel_id output parameter

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,8 @@ outputs:
     description: 'The timestamp on the message that was posted into Slack when using bot token'
   ts: # timestamp of message posted
     description: 'The timestamp on the message that was posted into Slack when using bot token'
+  channel_id: # Id of the channel. If channel name was used as input we can get ID from output for later use when updating message or posting to thread.
+    description: 'The channel id of the message that was posted into Slack when using bot token'
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/src/slack-send.js
+++ b/src/slack-send.js
@@ -145,6 +145,8 @@ module.exports = async function slackSend(core) {
       // return the thread_ts if it exists, if not return the ts
       const thread_ts = webResponse.thread_ts ? webResponse.thread_ts : webResponse.ts;
       core.setOutput('thread_ts', thread_ts);
+      // return id of the channel from the response
+      core.setOutput('channel_id', webResponse.channel);
     }
 
     const time = (new Date()).toTimeString();


### PR DESCRIPTION
###  Summary

We would like to use channel name for posting new messages instead of channel id. From the response we can get channel ID, export it as output parameter and use it later for updating messages or posting to threads the same way as we use ts or thread_ts.

Workaround/solution for #136.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).