### PR TITLE
[#171] Update Technique 2 to use Actions context instead of values property

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ By creating a new Slack app or using an existing one, this approach allows your 
 ## Setup
 
 * [Create a Slack App][apps] for your workspace (alternatively use an existing app you have already created and installed).
-* Add the [`chat.write`](https://api.slack.com/scopes/chat:write) bot scope under **OAuth & Permissions**.
+* Add the [`chat:write`](https://api.slack.com/scopes/chat:write) bot scope under **OAuth & Permissions**.
 * Install the app to your workspace.
 * Copy the app's Bot Token from the **OAuth & Permissions** page and [add it as a secret in your repo settings][repo-secret] named `SLACK_BOT_TOKEN`.
 * Invite the bot user into the channel you wish to post messages to (`/invite @bot_user_name`).

--- a/example-workflows/Technique_2_Slack_App/JSON_payload.yml
+++ b/example-workflows/Technique_2_Slack_App/JSON_payload.yml
@@ -31,9 +31,9 @@ jobs:
                     "type": "button",
                     "text": {
                       "type": "plain_text",
-                      "text": $values.button_text
+                      "text": "${{ github.sha }}"
                     },
-                    "url": $values.button_url
+                    "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   }
                 ]
               }
@@ -42,6 +42,3 @@ jobs:
           }
       env:
         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      values: |
-        button_text: ${{ github.sha }}
-        button_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
###  Summary

This pull request updates the docs and examples for Technique 2 to use [GitHub Actions Context](https://docs.github.com/en/actions/learn-github-actions/contexts) instead of the `values` property.

This fixes the error `Unexpected value 'values'` that was reported in #171 and matches the approach documented in the `README.md`.

You can find a working example of this update in the repo: [mwbrooks/slack-github-action-example](https://github.com/mwbrooks/slack-github-action-example)

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).