### PR TITLE
output ts,thread_ts,channel_id as array of values concat with comma

### DIFF
--- a/test/slack-send-test.js
+++ b/test/slack-send-test.js
@@ -4,8 +4,9 @@ const core = require('@actions/core');
 const github = require('@actions/github');
 const rewiremock = require('rewiremock/node');
 
+const postResult = { ok: true, ts: '1503435957.111111', thread_ts: '1503435956.000247', channel: 'abcd' };
 const ChatStub = {
-  postMessage: sinon.fake.resolves({ ok: true, ts: '1503435957.111111', thread_ts: '1503435956.000247' }),
+  postMessage: sinon.fake.resolves(postResult),
   update: sinon.fake.resolves({ ok: true, thread_ts: '1503435956.000247' }),
 };
 /* eslint-disable-next-line global-require */
@@ -116,6 +117,12 @@ describe('slack-send', () => {
         assert.oneOf('C987654', [firstChatArgs.channel, secondChatArgs.channel], 'Second comma-separated channel provided to postMessage');
         assert.equal(firstChatArgs.text, 'who let the dogs out?', 'Correct message provided to postMessage with first comma-separated channel');
         assert.equal(secondChatArgs.text, 'who let the dogs out?', 'Correct message provided to postMessage with second comma-separated channel');
+        assert.equal(fakeCore.setOutput.firstCall.firstArg, 'ts', 'Output name set to ts');
+        assert.equal(fakeCore.setOutput.firstCall.lastArg, `${postResult.ts},${postResult.ts}`, 'Output name set to ts values');
+        assert.equal(fakeCore.setOutput.secondCall.firstArg, 'thread_ts', 'Output name set to thread_ts');
+        assert.equal(fakeCore.setOutput.secondCall.lastArg, `${postResult.thread_ts},${postResult.thread_ts}`, 'Output name set to thread_ts values');
+        assert.equal(fakeCore.setOutput.thirdCall.firstArg, 'channel_id', 'Output name set to channel_id');
+        assert.equal(fakeCore.setOutput.thirdCall.lastArg, `${postResult.channel},${postResult.channel}`, 'Output name set to channel_id values');
       });
     });
     describe('sad path', () => {


### PR DESCRIPTION
###  Summary

Fixes bug where only the timestamp of the last channel was returned and thus couldnt update the message on all channels by passing the timestamp onto a future github action call

### Requirements (place an `x` in each `[ ]`)

* [C ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [ C] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).