### PR TITLE
Update payload integration test to escape invalid characters

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,7 +104,9 @@ jobs:
     - uses: actions/checkout@v3
     - run: npm ci && npm run build
     - name: Dump out GitHub Context
-      run: echo '${{ toJSON(github) }}'
+      run: echo $JSON
+      env:
+        JSON: ${{ toJSON(github) }}
     - name: Post message to Slack with Payload path
       id: slackPayloadFile
       uses: ./


### PR DESCRIPTION
###  Summary

With testing https://github.com/slackapi/slack-github-action/pull/205, in the PR https://github.com/slackapi/slack-github-action/pull/206 to make sure the integration tests run, it was determined that the `toJSON()` in the payload integration test doesn't seem to work to parse the body of a given PR if it contains characters that need to be escaped within a string (example error output can be found in [this test run](https://github.com/slackapi/slack-github-action/actions/runs/5134722650/jobs/9239300076)).

However, there is a workaround for this in which bash automatically escapes invalid characters in env variables ([see this issue for more info](https://github.com/actions/runner/issues/1656)). This PR adds in this workaround so that all future PRs will successfully parse as JSON, regardless of the contents of the PR description. After adding this testing update in the test integration PR, [the payload integration test ran successfully](https://github.com/slackapi/slack-github-action/actions/runs/5134920483/jobs/9239608704).

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).