### PR TITLE
Add instructions for developing with a local version of the action

### DIFF
--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -14,7 +14,7 @@ All you need to work with this project is a supported version of [Node.js](https
 ### Developing
 
 Iterate quickly by developing and testing a local copy of this action using `npm run local`.
-Information on setting up and configuring mocked events can be found in [`.github/workflows/local/README.md`](./.github/workflows/local/README.md).
+Information on setting up and configuring mocked events can be found in [`.github/workflows/local/README.md`](./workflows/local/README.md).
 
 ### Testing
 

--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -13,7 +13,7 @@ All you need to work with this project is a supported version of [Node.js](https
 
 ### Developing
 
-Iterate quickly by developing and testing a local copy of this action using `npm run local`.
+Iterate quickly by developing and testing a local version of this action using `npm run local`.
 Information on setting up and configuring mocked events can be found in [`.github/workflows/local/README.md`](./workflows/local/README.md).
 
 ### Testing

--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -13,9 +13,8 @@ All you need to work with this project is a supported version of [Node.js](https
 
 ### Developing
 
-Iterate quickly by developing with a local copy of this action using [nektos/act](https://github.com/nektos/act).
-
-Local runs can be performed with `npm run local` and information for configuring mocked events can be found in [`.github/workflows/local/README.md`](./.github/workflows/local/README.md).
+Iterate quickly by developing and testing a local copy of this action using `npm run local`.
+Information on setting up and configuring mocked events can be found in [`.github/workflows/local/README.md`](./.github/workflows/local/README.md).
 
 ### Testing
 

--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -11,6 +11,12 @@ All you need to work with this project is a supported version of [Node.js](https
 
 ## Tasks
 
+### Developing
+
+Iterate quickly by developing with a local copy of this action using [nektos/act](https://github.com/nektos/act).
+
+Local runs can be performed with `npm run local` and information for configuring mocked events can be found in [`.github/workflows/local/README.md`](./.github/workflows/local/README.md).
+
 ### Testing
 
 When testing locally, ensure at least linting and unit tests pass by running `npm test`.

--- a/.github/workflows/local/.env.example
+++ b/.github/workflows/local/.env.example
@@ -1,0 +1,4 @@
+# Rename this file to .env and update any variables to get started
+
+SLACK_BOT_TOKEN=xoxb-01010101-abcdefgh
+SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T0123456789/B0123456789/abcdefghijklmnopqrstuvwxyz

--- a/.github/workflows/local/.gitignore
+++ b/.github/workflows/local/.gitignore
@@ -1,0 +1,2 @@
+# Secret variables
+.env

--- a/.github/workflows/local/README.md
+++ b/.github/workflows/local/README.md
@@ -1,6 +1,6 @@
 # Local runs
 
-For a simple development experience, a local copy of this action can be used in experiments.
+For a simple development experience, a local version of this action can be used in experiments.
 
 **Requirements**:
 

--- a/.github/workflows/local/README.md
+++ b/.github/workflows/local/README.md
@@ -1,0 +1,25 @@
+# Local runs
+
+For a simple development experience, a local copy of this action can be used in experiments.
+
+**Requirements**:
+
+- An installation of [nektos/act](https://github.com/nektos/act)
+
+## Configuring secrets
+
+To use `${{ secrets.* }}` in the workflow, move `.env.example` to `.env` and update any variables.
+
+## Mocking event payloads
+
+Different event payloads can be mocked directly with changes to the `event.json` file.
+
+Reference: https://docs.github.com/en/webhooks/webhook-events-and-payloads
+
+## Updating the workflow
+
+The `local.yml` file contains the workflow used for testing. Updates to these steps can be made to test various functionalities.
+
+## Running an experiment
+
+Run the workflow using `npm run local`. The above configurations will be used to simulate an actual workflow run.

--- a/.github/workflows/local/event.json
+++ b/.github/workflows/local/event.json
@@ -1,0 +1,9 @@
+{
+  "pull_request": {
+    "user": {
+      "login": "dependabot"
+    },
+    "title": "Bump actions/checkout from 3 to 4",
+    "html_url": "https://github.com/slackapi/slack-github-action/pull/238"
+  }
+}

--- a/.github/workflows/local/local.yml
+++ b/.github/workflows/local/local.yml
@@ -1,0 +1,28 @@
+name: Local run
+
+# Requires mocking the "public" event to begin this workflow and avoid actual runs
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
+on:
+  public:
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout action
+      uses: actions/checkout@v4
+    - name: Build action
+      run: npm install && npm run build
+    - name: Send a message into channel
+      id: slack
+      uses: ./.
+      with:
+        payload: |
+          {
+            "repository": "${{ github.repository }}",
+            "pull_request_username": "${{ github.event.pull_request.user.login }}",
+            "pull_request_title": ${{ toJSON(github.event.pull_request.title) }},
+            "pull_request_url": "${{ github.event.pull_request.html_url }}"
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "lint": "eslint .",
+    "local": "act public --eventpath .github/workflows/local/event.json --secret-file .github/workflows/local/.env",
     "test:mocha": "nyc mocha --config .mocharc.json test/*-test.js",
     "test": "npm run lint && npm run test:mocha",
     "build": "npx @vercel/ncc build src/index.js --license licenses.txt"


### PR DESCRIPTION
###  Summary

This PR introduces instructions for developing with a local version of the action to improve the development experience. No longer are pushes and tags to a remote branch necessary.

These changes allow custom configurations to be made to the event payloads to test various cases, and different techniques can be tried with changes to the `local.yml` file.

At the moment only a simple `payload` is provided to mock [Technique 1](https://github.com/slackapi/slack-github-action#technique-1-slack-workflow-builder). I think this is alright to start as more events could be added over time, or experiments can just be performed locally.

Open to any thoughts on this!

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).