### PR TITLE
Pass secrets to approved workflow jobs

### DIFF
--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -22,6 +22,12 @@ When testing locally, ensure at least linting and unit tests pass by running `np
 Additionally, sending a PR is highly recommended with every change as there are several GitHub
 Actions jobs that execute what are effectively integration tests for this GitHub Action.
 
+#### Checks on PRs
+
+Actions that run the integration tests on PRs from a fork will require approval before running.
+These checks use stored secrets so the changes should be reviewed before approving the workflow to
+avoid accidently leaking tokens!
+
 ### Releasing
 
 * Check the status of this project's GitHub Milestone to be released for issues that should be shipped with the release.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,7 @@
 name: Tests
 on:
   pull_request_target:
+    types: [opened, synchronize]
   push:
     branches:
       - main

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        ref: ${{  github.event.pull_request.head.sha }}
+        ref: ${{ github.event.pull_request.head.sha }}
     - run: npm ci && npm run build
     - name: Post message to Slack via botToken
       id: slackToken
@@ -63,7 +63,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        ref: ${{  github.event.pull_request.head.sha }}
+        ref: ${{ github.event.pull_request.head.sha }}
     - run: npm ci && npm run build
     - run: echo "${{ github.event_name }}"
     - name: push trigger
@@ -99,7 +99,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        ref: ${{  github.event.pull_request.head.sha }}
+        ref: ${{ github.event.pull_request.head.sha }}
     - run: npm ci && npm run build
     - run: echo "${{ github.event_name }}"
     - name: Post message to Slack via incoming webhook
@@ -122,7 +122,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        ref: ${{  github.event.pull_request.head.sha }}
+        ref: ${{ github.event.pull_request.head.sha }}
     - run: npm ci && npm run build
     - name: Dump out GitHub Context
       run: echo $JSON

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Gather user permissions
-      if: ${{ github.event_name == 'pull_request' && github.event.pull_request.author_association != 'COLLABORATOR' }}
+      if: ${{ github.event_name == 'pull_request' && github.event.pull_request.author_association != 'MEMBER' }}
       run: |
         echo "Action was not triggered by a collaborator. Exiting now."
         exit 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,10 +13,22 @@ jobs:
     - run: npm ci && npm run build
     - run: npm test
 
-  integration_test_botToken:
+  access_check:
     runs-on: ubuntu-latest
     steps:
+    - name: Gather user permissions
+      if: ${{ github.event_name == 'pull_request' && github.event.pull_request.author_association != 'COLLABORATOR' }}
+      run: |
+        echo "Action was not triggered by a collaborator. Exiting now."
+        exit 1
+
+  integration_test_botToken:
+    runs-on: ubuntu-latest
+    needs: access_check
+    steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{  github.event.pull_request.head.sha }}
     - run: npm ci && npm run build
     - name: Post message to Slack via botToken
       id: slackToken
@@ -47,8 +59,11 @@ jobs:
 
   integration_test_webhook:
     runs-on: ubuntu-latest
+    needs: access_check
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{  github.event.pull_request.head.sha }}
     - run: npm ci && npm run build
     - run: echo "${{ github.event_name }}"
     - name: push trigger
@@ -80,8 +95,11 @@ jobs:
 
   integration_test_incoming_webhook:
     runs-on: ubuntu-latest
+    needs: access_check
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{  github.event.pull_request.head.sha }}
     - run: npm ci && npm run build
     - run: echo "${{ github.event_name }}"
     - name: Post message to Slack via incoming webhook
@@ -100,8 +118,11 @@ jobs:
 
   integration_test_file_payload:
     runs-on: ubuntu-latest
+    needs: access_check
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{  github.event.pull_request.head.sha }}
     - run: npm ci && npm run build
     - name: Dump out GitHub Context
       run: echo $JSON

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,8 @@ jobs:
     needs: access_check
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
     - run: npm ci && npm run build
     - name: Post message to Slack via botToken
       id: slackToken
@@ -60,6 +62,8 @@ jobs:
     needs: access_check
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
     - run: npm ci && npm run build
     - run: echo "${{ github.event_name }}"
     - name: push trigger
@@ -94,6 +98,8 @@ jobs:
     needs: access_check
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
     - run: npm ci && npm run build
     - run: echo "${{ github.event_name }}"
     - name: Post message to Slack via incoming webhook
@@ -115,6 +121,8 @@ jobs:
     needs: access_check
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
     - run: npm ci && npm run build
     - name: Dump out GitHub Context
       run: echo $JSON

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,10 +16,10 @@ jobs:
   access_check:
     runs-on: ubuntu-latest
     steps:
-    - name: Gather user permissions
+    - name: Check user permissions
       if: ${{ github.event_name == 'pull_request' && github.event.pull_request.author_association != 'MEMBER' }}
       run: |
-        echo "Action was not triggered by a collaborator. Exiting now."
+        echo "Action was not triggered by an organization member. Exiting now."
         exit 1
 
   integration_test_botToken:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,8 +27,6 @@ jobs:
     needs: access_check
     steps:
     - uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
     - run: npm ci && npm run build
     - name: Post message to Slack via botToken
       id: slackToken
@@ -62,8 +60,6 @@ jobs:
     needs: access_check
     steps:
     - uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
     - run: npm ci && npm run build
     - run: echo "${{ github.event_name }}"
     - name: push trigger
@@ -98,8 +94,6 @@ jobs:
     needs: access_check
     steps:
     - uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
     - run: npm ci && npm run build
     - run: echo "${{ github.event_name }}"
     - name: Post message to Slack via incoming webhook
@@ -121,8 +115,6 @@ jobs:
     needs: access_check
     steps:
     - uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
     - run: npm ci && npm run build
     - name: Dump out GitHub Context
       run: echo $JSON

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: Tests
 on:
-  pull_request:
+  pull_request_target:
   push:
     branches:
       - main


### PR DESCRIPTION
###  Summary

This PR attempts to pass secrets to integration tests for PRs opened from a fork. Fixes #251.

PRs not opened by a `COLLABORATOR` will initially fail because secrets "are not passed to workflows that are triggered by a pull request from a fork" but checking out the `head.sha` on a re-run is [an apparent workaround for this](https://michaelheap.com/access-secrets-from-forks/) and workflows can be re-run by a maintainer!

### Notes

- Other options for `author_associations` include [`MEMBER`](https://docs.github.com/en/graphql/reference/enums#commentauthorassociation) which might work better for the check in `access_check`. I think a re-run will pass this check in any case though 🤔

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).