### PR TITLE
build(node): bump the runtime version to node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,5 +26,5 @@ outputs:
   channel_id: # Id of the channel. If channel name was used as input we can get ID from output for later use when updating message or posting to thread.
     description: 'The channel id of the message that was posted into Slack when using bot token'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "url": "https://github.com/slackapi/slack-github-action/issues"
   },
   "engines": {
-    "node": ">=16.0.0",
-    "npm": ">=7.10.0"
+    "node": ">=20.0.0",
+    "npm": ">=10.2.0"
   },
   "homepage": "https://github.com/slackapi/slack-github-action#readme",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "lint": "eslint .",
-    "local": "act public --eventpath .github/workflows/local/event.json --secret-file .github/workflows/local/.env",
+    "local": "act public --eventpath .github/workflows/local/event.json --secret-file .github/workflows/local/.env --platform ubuntu-latest=node:20-buster",
     "test:mocha": "nyc mocha --config .mocharc.json test/*-test.js",
     "test": "npm run lint && npm run test:mocha",
     "build": "npx @vercel/ncc build src/index.js --license licenses.txt"


### PR DESCRIPTION
### Summary

This PR bumps the version of Node to [the active LTS](https://nodejs.org/en/about/previous-releases#release-schedule) (Node 20) to remain current with packages that have dropped support for Node 16.

The updated runtime doesn't seem to be a breaking change as the action is [executed using this runtime](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsusing-for-javascript-actions) without being specified by the calling workflow, but willing to adjust the semver if needed!

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).