### PR TITLE
Unit tests in GitHub CI should test the PR/branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
     - run: npm ci && npm run build
     - run: npm test
 


### PR DESCRIPTION
Without specifying the ref to check out, `checkout@v4` will check out the default branch, which is `main`. 😑 not helpful