### PR TITLE
ci(security): require access checks to pass before running unit tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,15 @@ on:
       - main
 
 jobs:
+  # Note: The `pull_request_target` event provides access to repository secrets!
+  #
+  # This is required to run the integration tests on PRs from forked branches.
+  # Any job checking out pull_request.head.sha should require the access_check.
+  #
+  # Actions require collaborator approval to start and might require a re-run.
+  # The proposed changes should be reviewed before approving any workflow jobs.
+  #
+  # Reference: https://michaelheap.com/access-secrets-from-forks/
   access_check:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,15 +7,6 @@ on:
       - main
 
 jobs:
-  unit_tests:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
-    - run: npm ci && npm run build
-    - run: npm test
-
   access_check:
     runs-on: ubuntu-latest
     steps:
@@ -24,6 +15,16 @@ jobs:
       run: |
         echo "Action was not triggered by an organization member. Exiting now."
         exit 1
+
+  unit_tests:
+    runs-on: ubuntu-latest
+    needs: access_check
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+    - run: npm ci && npm run build
+    - run: npm test
 
   integration_test_botToken:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Summary

This PR requires the `access_check` step to pass before running `unit_tests` to prevent unexpected changes from branched PRs happening in actions.

A note about the `access_check` is also added to the workflow file.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).