### PR TITLE
Make payload delimiter configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This technique sends data into Slack via a webhook URL created using [Slack's Wo
 As part of the [workflow setup](https://slack.com/help/articles/360041352714-Create-more-advanced-workflows-using-webhooks#workflow-setup),
 you will need to define expected variables in the payload the webhook will receive (described in the "Create custom variables" section of the docs). If these variables are missing in the payload, an error is returned.
 
-To match the webhook input format expected by Workflow Builder, the payload will be flattened and stringified (all nested keys are moved to the top level) before being sent. The default delimiter used to flatten payloads is a period (".") but should be changed to an underscore ("_") using the `payload-delimiter` parameter if you're using these as input values in your own workflows.
+To match the webhook input format expected by Workflow Builder, the payload will be flattened and stringified (all nested keys are moved to the top level) before being sent. The default delimiter used to flatten payloads is a period (".") but should be changed to an underscore ("_") using the `payload-delimiter` parameter if you're using nested payloads as input values in your own workflows.
 
 #### Setup
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ The recommended way to use this action is with Slack's Workflow Builder (if you'
 
 This technique sends data into Slack via a webhook URL created using [Slack's Workflow builder](https://slack.com/features/workflow-automation). Follow [these steps to create a Slack workflow using webhooks][create-webhook]. The Slack workflow webhook URL will be in the form `https://hooks.slack.com/workflows/....`. The payload sent by this GitHub action will be flattened (all nested keys moved to the top level) and stringified since Slack's workflow builder only supports top level string values in payloads.
 
+By default, payloads are flattened with a period (".") as the delimiter, but the Slack Workflow Builder does not accept periods in variable keys, so you must define the `payload-delimiter` input in order to access values below the top level of the payload.
+
 As part of the [workflow setup](https://slack.com/help/articles/360041352714-Create-more-advanced-workflows-using-webhooks#workflow-setup),
 you will need to define expected variables in the payload the webhook will receive (described in the "Create custom variables" section of the docs). If these variables are missing in the payload, an error is returned.
 

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ The recommended way to use this action is with Slack's Workflow Builder (if you'
 
 > ❗️ This approach requires a paid Slack plan; it also doesn't support any text formatting
 
-This technique sends data into Slack via a webhook URL created using [Slack's Workflow builder](https://slack.com/features/workflow-automation). Follow [these steps to create a Slack workflow using webhooks][create-webhook]. The Slack workflow webhook URL will be in the form `https://hooks.slack.com/workflows/....`. The payload sent by this GitHub action will be flattened (all nested keys moved to the top level) and stringified since Slack's workflow builder only supports top level string values in payloads.
-
-By default, payloads are flattened with a period (".") as the delimiter, but the Slack Workflow Builder does not accept periods in variable keys, so you must define the `payload-delimiter` input in order to access values below the top level of the payload.
+This technique sends data into Slack via a webhook URL created using [Slack's Workflow builder](https://slack.com/features/workflow-automation). Follow [these steps to create a Slack workflow using webhooks][create-webhook]. The Slack workflow webhook URL will be in the form `https://hooks.slack.com/workflows/....`.
 
 As part of the [workflow setup](https://slack.com/help/articles/360041352714-Create-more-advanced-workflows-using-webhooks#workflow-setup),
 you will need to define expected variables in the payload the webhook will receive (described in the "Create custom variables" section of the docs). If these variables are missing in the payload, an error is returned.
+
+To match the webhook input format expected by Workflow Builder, the payload will be flattened and stringified (all nested keys are moved to the top level) before being sent. The default delimiter used to flatten payloads is a period (".") but should be changed to an underscore ("_") using the `payload-delimiter` parameter if you're using these as input values in your own workflows.
 
 #### Setup
 
@@ -46,6 +46,8 @@ Add this Action as a [step][job-step] to your project's GitHub Action Workflow f
 - name: Send GitHub Action trigger data to Slack workflow
   id: slack
   uses: slackapi/slack-github-action@v1.26.0
+  with:
+    payload-delimiter: "_"
   env:
     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
   payload: # JSON payload to send to Slack via webhook
     description: 'JSON payload to send to Slack if webhook route. If not supplied, json from GitHub event will be sent instead'
     required: false
+  payload-delimiter: # custom delimiter used to flatten nested values in the JSON payload
+    description: 'Custom delimiter used to flatten nested values in the JSON payload. If not supplied, defaults to a period (".").'
+    required: false
   payload-file-path: # path to JSON payload to send to Slack via webhook
     description: 'path to JSON payload to send to Slack if webhook route. If not supplied, json from GitHub event will be sent instead. If payload is provided, it will take preference over this field'
     required: false

--- a/src/slack-send.js
+++ b/src/slack-send.js
@@ -98,8 +98,9 @@ module.exports = async function slackSend(core) {
       }
 
       if (webhookType === SLACK_WEBHOOK_TYPES.WORKFLOW_TRIGGER) {
-        // flatten JSON payload (no nested attributes), with nested keys delimited with underscores.
-        const flatPayload = flatten(payload, { delimiter: '_' });
+        // flatten JSON payload (no nested attributes).
+        const payloadDelimiter = core.getInput('payload-delimiter') || '.';
+        const flatPayload = flatten(payload, { delimiter: payloadDelimiter });
 
         // workflow builder requires values to be strings
         // iterate over every value and convert it to string

--- a/src/slack-send.js
+++ b/src/slack-send.js
@@ -98,8 +98,8 @@ module.exports = async function slackSend(core) {
       }
 
       if (webhookType === SLACK_WEBHOOK_TYPES.WORKFLOW_TRIGGER) {
-        // flatten JSON payload (no nested attributes)
-        const flatPayload = flatten(payload);
+        // flatten JSON payload (no nested attributes), with nested keys delimited with underscores.
+        const flatPayload = flatten(payload, { delimiter: '_' });
 
         // workflow builder requires values to be strings
         // iterate over every value and convert it to string


### PR DESCRIPTION
Fixes #280.

###  Summary

The default key delimiter when flattening payloads is a period, which is not allowed in Slack workflow variable keys. This makes the `slack-send` action unusable with Slack workflows/incoming webhooks if the payload contains nested keys as there is no way to access those keys (as far as I can tell).

For example if I want to include workflow metadata from GitHub in my payload with `${{ toJson(github) }}`, all nested keys are inaccessible, and if I want to compose this with other custom variables by nesting the serialized `github` values like `"github": ${{ toJson(github) }}, "some-key": "some-value"`, then all of the GitHub metadata is inaccessible because it's all prefixed with `github.` and can't be entered as a variable key in a Slack workflow. Underscores and hyphens are both valid, so changing to an underscore makes all those nested keys accessible. See [`flat` docs](https://www.npmjs.com/package/flat#delimiter)

Tested on a private workflow by building and calling the action directly from my branch.

This leaves the default as a period but allows users to override it by setting the `payload-delimiter` option alongside the payload sent to the action.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).