### PR TITLE
ci(security): check for pull_request_target events in the access check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check user permissions
-      if: ${{ github.event_name == 'pull_request' && github.event.pull_request.author_association != 'MEMBER' }}
+      if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.author_association != 'MEMBER' }}
       run: |
         echo "Action was not triggered by an organization member. Exiting now."
         exit 1


### PR DESCRIPTION
###  Summary

This PR updates the `access_check` to check that the event is a a `pull_request_target` instead of a `pull_request`.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).