### PR TITLE
ci(test): collect environment secrets from a prepared staging environment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,47 +1,22 @@
 name: Tests
 on:
-  pull_request_target:
-    types: [opened, synchronize]
+  pull_request:
   push:
     branches:
       - main
 
 jobs:
-  # Note: The `pull_request_target` event provides access to repository secrets!
-  #
-  # This is required to run the integration tests on PRs from forked branches.
-  # Any job checking out pull_request.head.sha should require the access_check.
-  #
-  # Actions require collaborator approval to start and might require a re-run.
-  # The proposed changes should be reviewed before approving any workflow jobs.
-  #
-  # Reference: https://michaelheap.com/access-secrets-from-forks/
-  access_check:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Check user permissions
-      if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.author_association != 'MEMBER' }}
-      run: |
-        echo "Action was not triggered by an organization member. Exiting now."
-        exit 1
-
   unit_tests:
     runs-on: ubuntu-latest
-    needs: access_check
     steps:
     - uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
     - run: npm ci && npm run build
     - run: npm test
 
   integration_test_botToken:
     runs-on: ubuntu-latest
-    needs: access_check
     steps:
     - uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
     - run: npm ci && npm run build
     - name: Post message to Slack via botToken
       id: slackToken
@@ -72,11 +47,8 @@ jobs:
 
   integration_test_webhook:
     runs-on: ubuntu-latest
-    needs: access_check
     steps:
     - uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
     - run: npm ci && npm run build
     - run: echo "${{ github.event_name }}"
     - name: push trigger
@@ -108,11 +80,8 @@ jobs:
 
   integration_test_incoming_webhook:
     runs-on: ubuntu-latest
-    needs: access_check
     steps:
     - uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
     - run: npm ci && npm run build
     - run: echo "${{ github.event_name }}"
     - name: Post message to Slack via incoming webhook
@@ -131,11 +100,8 @@ jobs:
 
   integration_test_file_payload:
     runs-on: ubuntu-latest
-    needs: access_check
     steps:
     - uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
     - run: npm ci && npm run build
     - name: Dump out GitHub Context
       run: echo $JSON

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ jobs:
 
   integration_test_botToken:
     runs-on: ubuntu-latest
+    environment: staging
     steps:
     - uses: actions/checkout@v4
     - run: npm ci && npm run build
@@ -47,6 +48,7 @@ jobs:
 
   integration_test_webhook:
     runs-on: ubuntu-latest
+    environment: staging
     steps:
     - uses: actions/checkout@v4
     - run: npm ci && npm run build
@@ -80,6 +82,7 @@ jobs:
 
   integration_test_incoming_webhook:
     runs-on: ubuntu-latest
+    environment: staging
     steps:
     - uses: actions/checkout@v4
     - run: npm ci && npm run build
@@ -100,6 +103,7 @@ jobs:
 
   integration_test_file_payload:
     runs-on: ubuntu-latest
+    environment: staging
     steps:
     - uses: actions/checkout@v4
     - run: npm ci && npm run build


### PR DESCRIPTION
### Summary

This PR updates the integration tests to use [a `staging` environment](https://github.com/slackapi/slack-github-action/settings/environments/2483877568/edit) 🔐 for workflow jobs. This staging environment has an access check that requires approval from @slackapi/developer-tools and then grants access to environment secrets when running the jobs.

The previous `pull_request_target` `access_check` checks were reverted here but a note remains in the [maintainer's guide](https://github.com/slackapi/slack-github-action/blob/main/.github/maintainers_guide.md#checks-on-prs).

### Notes

Using environment might act as a "deployment" which will appear on the repo home page. I suggest we hide this since the `staging` environment is only used in testing.

### Reference

- https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment
- https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-an-environment

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).