### PR TITLE
docs(readme): adjust whitespace in env assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Please note that **the message update step does not accept a channel name.** Set
         ]
       }
   env:
-    SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN}}
+    SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 - uses: slackapi/slack-github-action@v1.25.0
   with:
     # Unlike the step posting a new message, this step does not accept a channel name.
@@ -191,7 +191,7 @@ Please note that **the message update step does not accept a channel name.** Set
         ]
       }
   env:
-    SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN}}
+    SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 ```
 
 ### Technique 3: Slack Incoming Webhook


### PR DESCRIPTION
###  Summary

This PR adjust a missing whitespace in README.
Now all env vars have the same pattern `${{ value }}` instead of `${{ value}}`.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).