### PR TITLE
ci(test): share environment secrets with pull requests from forked prs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   unit_tests:
     runs-on: ubuntu-latest
+    environment: staging
     steps:
     - uses: actions/checkout@v4
     - run: npm ci && npm run build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: Tests
 on:
-  pull_request:
+  pull_request_target:
   push:
     branches:
       - main
@@ -11,6 +11,8 @@ jobs:
     environment: staging
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
     - run: npm ci && npm run build
     - run: npm test
 
@@ -19,6 +21,8 @@ jobs:
     environment: staging
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
     - run: npm ci && npm run build
     - name: Post message to Slack via botToken
       id: slackToken
@@ -52,6 +56,8 @@ jobs:
     environment: staging
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
     - run: npm ci && npm run build
     - run: echo "${{ github.event_name }}"
     - name: push trigger
@@ -86,6 +92,8 @@ jobs:
     environment: staging
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
     - run: npm ci && npm run build
     - run: echo "${{ github.event_name }}"
     - name: Post message to Slack via incoming webhook
@@ -107,6 +115,8 @@ jobs:
     environment: staging
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
     - run: npm ci && npm run build
     - name: Dump out GitHub Context
       run: echo $JSON


### PR DESCRIPTION
###  Summary

This PR reverts reverted changes in an attempt (the final attempt) to share environment secrets with PRs from a forked repository.

Some things to maybe note include:

- The `pull_request_target` [runs these jobs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) with access to secrets. And the `environment` that all of these jobs run in requires approval. So the secrets should be safe with some pre-approval checks!
- The `event.pull_request.head.sha` is checked out in each job so the code of the PR is actually being tested.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).