### PR TITLE
ci: include the slack health score as part of ci tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,3 +117,10 @@ jobs:
 
     - name: "integration(incoming): confirm a payload file was posted"
       run: test -n "${{ steps.slackPayloadFile.outputs.time }}"
+
+    - name: "chore(health): check up on recent changes to the health score"
+      uses: slackapi/slack-health-score@v0.1.1
+      with:
+        codecov_token: ${{ secrets.CODECOV_TOKEN }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        extension: js


### PR DESCRIPTION
### Summary

This PR adds the 🏥 [slackapi/slack-health-score](https://github.com/slackapi/slack-health-score) to this action as part of regular check ups!

Hopes to fix strangeness that happens when [adding this action another PR](https://github.com/slackapi/slack-github-action/actions/runs/11131514332/job/30933247951?pr=333#step:31:11). I'm hoping this fixes missing commits, but am unsure if this is a real fix 😳 

### Notes

Please forgive the misuse of a `diff` but these are the errors shown in the other run:

```diff
> Run slackapi/slack-health-score@v0.1.1
    with:
      codecov_token: ***
      github_token: ***
      extension: js
    env:
      EVENT_URL: https://github.com/slackapi/slack-github-action/pull/333
  Using SHA: 7c719bb2a1a67ec8972d7edd09a24c26856f306f
  Pinging codecov API for coverage data...
- Error: Failed to retrieve codecov commits
- Error: FetchError: Unauthorized
- Warning: Directories to be included not specified
- Error: Error: spawnSync /bin/sh ENOBUFS
- Error: child_process execSync failed to execute
  {
    "comments": [],
    "coverageMisses": 0
  }
  Using SHA: 7c719bb2a1a67ec8972d7edd09a24c26856f306f
  -0
```

### More notes

- Formatting of the `main.yml` is left to another PR or future change - hoping to keep this diff small ✨ 

### Requirements 

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).