### PR TITLE
docs: fix incorrect parameter name in uploadV2 (channel -> channel_id)

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ convenience of the [`files.uploadV2`][files.uploadV2] method:
     method: files.uploadV2
     token: ${{ secrets.SLACK_BOT_TOKEN }}
     payload: |
-      channel: ${{ secrets.SLACK_CHANNEL_ID }}
+      channel_id: ${{ secrets.SLACK_CHANNEL_ID }}
       initial_comment: "the results are in!"
       file: "results.out"
       filename: "results-${{ github.sha }}.out"


### PR DESCRIPTION
### Summary

While implementing functionality as per the documentation, the channel parameter did not work as expected. Upon reviewing the official reference [Upload a File - Slack API Documentation](https://tools.slack.dev/node-slack-sdk/web-api/#upload-a-file), I noticed that the correct parameter is channel_id. After making this change, the functionality worked as intended.

This PR proposes a fix to update the documentation to reflect the correct parameter, ensuring that other users do not encounter the same issue.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).