### PR TITLE
fix: avoid erroring if conflicting techniques are set from environment variables

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -111,7 +111,7 @@ export default class Config {
       webhookType: core.getInput("webhook-type"),
     };
     this.mask();
-    this.validate();
+    this.validate(core);
     core.debug(`Gathered action inputs: ${JSON.stringify(this.inputs)}`);
     this.content = new Content().get(this);
     core.debug(`Parsed request content: ${JSON.stringify(this.content)}`);
@@ -133,8 +133,9 @@ export default class Config {
 
   /**
    * Confirm the configurations are correct enough to continue.
+   * @param {core} core - GitHub Actions core utilities.
    */
-  validate() {
+  validate(core) {
     switch (this.inputs.retries.trim().toUpperCase()) {
       case this.Retries.ZERO:
       case this.Retries.FIVE:
@@ -148,10 +149,10 @@ export default class Config {
         );
     }
     switch (true) {
-      case !!this.inputs.method && !!this.inputs.webhook:
+      case !!core.getInput("token") && !!core.getInput("webhook"):
         throw new SlackError(
           core,
-          "Invalid input! Either the method or webhook is required - not both.",
+          "Invalid input! Either the token or webhook is required - not both.",
         );
       case !!this.inputs.method:
         if (!this.inputs.token) {

--- a/src/send.js
+++ b/src/send.js
@@ -29,7 +29,7 @@ export default async function send(core) {
  */
 async function post(config) {
   switch (true) {
-    case !!config.inputs.token:
+    case !!config.inputs.method:
       return await new Client().post(config);
     case !!config.inputs.webhook:
       return await new Webhook().post(config);

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -61,6 +61,8 @@ export class Mock {
     this.core.getInput.reset();
     this.core.getInput.withArgs("errors").returns("false");
     this.core.getInput.withArgs("retries").returns("5");
+    process.env.SLACK_TOKEN = "";
+    process.env.SLACK_WEBHOOK_URL = "";
   }
 }
 

--- a/test/send.spec.js
+++ b/test/send.spec.js
@@ -39,6 +39,7 @@ describe("send", () => {
     });
 
     it("token", async () => {
+      process.env.SLACK_WEBHOOK_URL = "https://example.com"; // https://github.com/slackapi/slack-github-action/issues/373
       mocks.api.resolves({ ok: true });
       mocks.core.getInput.withArgs("method").returns("chat.postMessage");
       mocks.core.getInput.withArgs("token").returns("xoxb-example");

--- a/test/send.spec.js
+++ b/test/send.spec.js
@@ -56,7 +56,7 @@ describe("send", () => {
     });
 
     it("incoming webhook", async () => {
-      mocks.core.getInput.withArgs("token").returns("xoxb-example"); // https://github.com/slackapi/slack-github-action/issues/373
+      process.env.SLACK_TOKEN = "xoxb-example"; // https://github.com/slackapi/slack-github-action/issues/373
       mocks.core.getInput
         .withArgs("webhook")
         .returns("https://hooks.slack.com");

--- a/test/send.spec.js
+++ b/test/send.spec.js
@@ -56,6 +56,7 @@ describe("send", () => {
     });
 
     it("incoming webhook", async () => {
+      mocks.core.getInput.withArgs("token").returns("xoxb-example"); // https://github.com/slackapi/slack-github-action/issues/373
       mocks.core.getInput
         .withArgs("webhook")
         .returns("https://hooks.slack.com");


### PR DESCRIPTION
### Summary

This PR allows both environment variables `SLACK_TOKEN` and `SLACK_WEBHOOK_URL` to exist in a workflow without causing steps to error due to an undefined technique! Fixes #373.

### Reviewers

Add the following to the workflow in `develop.yml` before running with `npm run dev`:

```diff
+   env:
+     SLACK_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
    runs-on: ubuntu-latest
```

This should error before the change is applied but not after!

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).