### PR TITLE
ci: reduce the permissions for github actions jobs

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   run:
     runs-on: ubuntu-latest
+    permissions:
+      contents: none
     steps:
       - name: Checkout action
         uses: actions/checkout@v4

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -8,8 +8,6 @@ on:
 jobs:
   run:
     runs-on: ubuntu-latest
-    permissions:
-      contents: none
     steps:
       - name: Checkout action
         uses: actions/checkout@v4

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout action
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup the Node runtime for this project
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,8 @@ jobs:
   build:
     name: Build and tag a new version
     runs-on: ubuntu-latest
+    permissions:
+      contents: none
     steps:
       - name: Checkout the current code
         uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,7 @@ jobs:
       - name: Checkout the current code
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           ref: ${{ github.event.release.tag_name }}
 
       - name: Configure the runtime node

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     name: Build and tag a new version
     runs-on: ubuntu-latest
     permissions:
-      contents: none
+      contents: write
     steps:
       - name: Checkout the current code
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,8 @@ jobs:
     name: Run tests
     runs-on: ubuntu-latest
     environment: staging
+    permissions:
+      contents: none
     steps:
       - name: "build: checkout the latest changes"
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -229,7 +229,7 @@ jobs:
       - name: "chore(health): check up on recent changes to the health score"
         uses: slackapi/slack-health-score@v0.1.1
         with:
-          codecov_token: ${{ secrets.CODECOV_TOKEN }}
+          codecov_token: ${{ secrets.CODECOV_API_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           extension: js
           include: src

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: staging
     permissions:
-      contents: none
+      checks: write
     steps:
       - name: "build: checkout the latest changes"
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
       - name: "build: checkout the latest changes"
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: "build: setup the node runtime"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slack-github-action",
-  "version": "2.0.1-rc.1",
+  "version": "2.0.1-rc.2",
   "description": "The official Slack Github Action. Use this to send data into your Slack workspace",
   "main": "dist/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slack-github-action",
-  "version": "2.0.0",
+  "version": "2.0.1-rc.1",
   "description": "The official Slack Github Action. Use this to send data into your Slack workspace",
   "main": "dist/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slack-github-action",
-  "version": "2.0.1-rc.2",
+  "version": "2.0.0",
   "description": "The official Slack Github Action. Use this to send data into your Slack workspace",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
### Summary

Small update to avoid persisting `git` credentials between steps of an action, and reduces the permissions of each `$GITHUB_TOKEN` to the minimum required.

This makes no changes to how the [`$GITHUB_TOKEN` can be accessed](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#about-the-github_token-secret) from the workflow!

### Preview

These changes were tested on a forked `main`:

- `develop.yml`: No changes!
- `publish.yml`: https://github.com/zimeg/slack-github-action/actions/runs/12321675869/job/34394241333
- `test.yml`: https://github.com/zimeg/slack-github-action/actions/runs/12321990320/job/34394566023

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).