### PR TITLE
refactor: setup the logger using core configuration values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@actions/core": "^1.11.1",
         "@actions/github": "^6.0.0",
+        "@slack/logger": "^4.0.0",
         "@slack/web-api": "^7.8.0",
         "axios": "^1.8.2",
         "axios-retry": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@actions/core": "^1.11.1",
     "@actions/github": "^6.0.0",
+    "@slack/logger": "^4.0.0",
     "@slack/web-api": "^7.8.0",
     "axios": "^1.8.2",
     "axios-retry": "^4.5.0",

--- a/src/client.js
+++ b/src/client.js
@@ -1,4 +1,4 @@
-import webapi, { LogLevel } from "@slack/web-api";
+import webapi from "@slack/web-api";
 import { HttpsProxyAgent } from "https-proxy-agent";
 import Config from "./config.js";
 import SlackError from "./errors.js";
@@ -24,18 +24,8 @@ export default class Client {
     }
     const client = new config.webapi.WebClient(config.inputs.token, {
       agent: this.proxies(config)?.httpsAgent,
+      logger: config.logger,
       retryConfig: this.retries(config.inputs.retries),
-      logger: {
-        debug: config.core.debug,
-        info: config.core.info,
-        warn: config.core.warning,
-        error: config.core.error,
-        getLevel: () => {
-          return config.core.isDebug() ? LogLevel.DEBUG : LogLevel.INFO;
-        },
-        setLevel: (_level) => {},
-        setName: (_name) => {},
-      },
     });
     try {
       /**

--- a/src/config.js
+++ b/src/config.js
@@ -3,6 +3,7 @@ import webapi from "@slack/web-api";
 import axios from "axios";
 import Content from "./content.js";
 import SlackError from "./errors.js";
+import Logger from "./logger.js";
 
 /**
  * Options and settings set as inputs to this action.
@@ -74,6 +75,12 @@ export default class Config {
   core;
 
   /**
+   * The logger of outputs.
+   * @type {import("@slack/logger").Logger}
+   */
+  logger;
+
+  /**
    * @type {import("@slack/web-api")} - Slack API client.
    */
   webapi;
@@ -91,6 +98,7 @@ export default class Config {
   constructor(core) {
     this.axios = axios;
     this.core = core;
+    this.logger = new Logger(core).logger;
     this.webapi = webapi;
     this.inputs = {
       errors: core.getBooleanInput("errors"),

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,32 @@
+import { LogLevel } from "@slack/logger";
+
+/**
+ * The Logger class creates a Logger to output debug messages and errors.
+ *
+ * @see {@link https://tools.slack.dev/node-slack-sdk/web-api/#logging}
+ */
+export default class Logger {
+  /**
+   * The logger for outputs.
+   * @type {import("@slack/logger").Logger}
+   */
+  logger;
+
+  /**
+   * Shared utilities specific to the GitHub action workflow.
+   * @param {import("@actions/core")} core - GitHub Actions core utilities.
+   */
+  constructor(core) {
+    this.logger = {
+      debug: core.debug,
+      info: core.info,
+      warn: core.warning,
+      error: core.error,
+      getLevel: () => {
+        return core.isDebug() ? LogLevel.DEBUG : LogLevel.INFO;
+      },
+      setLevel: (_level) => {},
+      setName: (_name) => {},
+    };
+  }
+}

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -48,12 +48,10 @@ export class Mock {
     this.core = this.sandbox.stub(core);
     this.fs = this.sandbox.stub(fs);
     this.webapi = {
-      WebClient: function() {
-        this.apiCall = function() {
-          return {
-            ok: true,
-          }
-        }
+      WebClient: function () {
+        this.apiCall = () => ({
+          ok: true,
+        });
       },
     };
     this.core.getInput.withArgs("errors").returns("false");

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -47,6 +47,15 @@ export class Mock {
     this.axios = this.sandbox.stub(axios);
     this.core = this.sandbox.stub(core);
     this.fs = this.sandbox.stub(fs);
+    this.webapi = {
+      WebClient: function() {
+        this.apiCall = function() {
+          return {
+            ok: true,
+          }
+        }
+      },
+    };
     this.core.getInput.withArgs("errors").returns("false");
     this.core.getInput.withArgs("retries").returns("5");
   }

--- a/test/logger.spec.js
+++ b/test/logger.spec.js
@@ -1,0 +1,29 @@
+import core from "@actions/core";
+import { LogLevel } from "@slack/logger";
+import { assert } from "chai";
+import Logger from "../src/logger.js";
+import { mocks } from "./index.spec.js";
+
+describe("logger", () => {
+  beforeEach(() => {
+    mocks.reset();
+  });
+
+  describe("level", () => {
+    it("debug", () => {
+      mocks.core.isDebug = () => true;
+      const { logger } = new Logger(core);
+      const actual = logger.getLevel();
+      const expected = LogLevel.DEBUG;
+      assert.equal(actual, expected);
+    });
+
+    it("info", () => {
+      mocks.core.isDebug = () => false;
+      const { logger } = new Logger(core);
+      const actual = logger.getLevel();
+      const expected = LogLevel.INFO;
+      assert.equal(actual, expected);
+    });
+  });
+});


### PR DESCRIPTION
### Summary

This PR refactors the `logger` setup used for `@slack/web-api` to a standalone file to test that the configured action inputs are used when constructing the `WebClient` 👾 

Hopefully no changes to functionality, but an improvement to testing for following changes!

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).