### PR TITLE
build(deps): bump @slack/web-api to 7.8.0 to 7.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@actions/core": "^1.11.1",
         "@actions/github": "^6.0.0",
         "@slack/logger": "^4.0.0",
-        "@slack/web-api": "^7.8.0",
+        "@slack/web-api": "^7.9.0",
         "axios": "^1.8.2",
         "axios-retry": "^4.5.0",
         "flat": "^6.0.1",
@@ -660,16 +660,16 @@
       }
     },
     "node_modules/@slack/web-api": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.8.0.tgz",
-      "integrity": "sha512-d4SdG+6UmGdzWw38a4sN3lF/nTEzsDxhzU13wm10ejOpPehtmRoqBKnPztQUfFiWbNvSb4czkWYJD4kt+5+Fuw==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.9.0.tgz",
+      "integrity": "sha512-PEvscTsHj4pLQr6g/0OwPEFDN9ElJMdba9uYvhTPjC2yGQGzjB4YmqilXaDX0Lm3IBEcLtJNRAbsfQp+x3X3Qg==",
       "license": "MIT",
       "dependencies": {
         "@slack/logger": "^4.0.0",
         "@slack/types": "^2.9.0",
         "@types/node": ">=18.0.0",
         "@types/retry": "0.12.0",
-        "axios": "^1.7.8",
+        "axios": "^1.8.3",
         "eventemitter3": "^5.0.1",
         "form-data": "^4.0.0",
         "is-electron": "2.2.2",
@@ -853,9 +853,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
-      "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@actions/core": "^1.11.1",
     "@actions/github": "^6.0.0",
     "@slack/logger": "^4.0.0",
-    "@slack/web-api": "^7.8.0",
+    "@slack/web-api": "^7.9.0",
     "axios": "^1.8.2",
     "axios-retry": "^4.5.0",
     "flat": "^6.0.1",


### PR DESCRIPTION
### Summary

This PR bumps `@slack/web-api` to [7.9.0](https://github.com/slackapi/node-slack-sdk/releases/tag/%40slack%2Fweb-api%407.9.0) for the updates of https://github.com/slackapi/node-slack-sdk/pull/2172 🤖 


### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).