### PR TITLE
docs: pulls out variables into separate page

### DIFF
--- a/docs/sending-variables.md
+++ b/docs/sending-variables.md
@@ -1,0 +1,19 @@
+# Slack Send GitHub Action
+
+The GitHub Action for sending data to Slack.
+
+## Versioning
+
+We recommend using the latest version of this GitHub Action for the most recent updates and fixes.
+
+Migration guides are available in the [release notes](https://github.com/slackapi/slack-github-action/releases) with breaking changes noted between versions.
+
+Changes required when upgrading from `@v1` to `@v2` are included in this [migration guide](https://github.com/slackapi/slack-github-action/releases/tag/v2.0.0).
+
+## License
+
+This project is licensed under the [MIT license](https://github.com/slackapi/slack-github-action/blob/main/LICENSE).
+
+## Contributing
+
+All contributions are encouraged! Check out the [contributor's guide](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) to learn more.

--- a/docs/sending-variables.md
+++ b/docs/sending-variables.md
@@ -1,19 +1,12 @@
-# Slack Send GitHub Action
+# Sending variables 
 
-The GitHub Action for sending data to Slack.
+There are different [techniques to send data](/slack-github-action/sending-techniques) into Slack and whichever one is chosen will require a certain set of customized inputs, as described later.
 
-## Versioning
+You can provide data to send to Slack from this GitHub Action and either source:
 
-We recommend using the latest version of this GitHub Action for the most recent updates and fixes.
+- The default event [context](https://github.com/actions/toolkit/blob/main/packages/github/src/context.ts#L6) with a [payload](https://docs.github.com/en/webhooks/webhook-events-and-payloads) matching the GitHub event.
+- A custom payload with optional [variables](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables) provided in the GitHub Action step.
 
-Migration guides are available in the [release notes](https://github.com/slackapi/slack-github-action/releases) with breaking changes noted between versions.
+These input options are valid for all techniques, but some techniques require specific constraints with certain requirements for valid inputs.
 
-Changes required when upgrading from `@v1` to `@v2` are included in this [migration guide](https://github.com/slackapi/slack-github-action/releases/tag/v2.0.0).
-
-## License
-
-This project is licensed under the [MIT license](https://github.com/slackapi/slack-github-action/blob/main/LICENSE).
-
-## Contributing
-
-All contributions are encouraged! Check out the [contributor's guide](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) to learn more.
+Additional [configurations](/slack-github-action/additional-configurations) and other details are also available for more customizations to the provided payload.

--- a/docs/slack-github-action.md
+++ b/docs/slack-github-action.md
@@ -2,19 +2,6 @@
 
 The GitHub Action for sending data to Slack.
 
-## Sending variables 
-
-There are different [techniques to send data](/slack-github-action/sending-techniques) into Slack and whichever one is chosen will require a certain set of customized inputs, as described later.
-
-You can provide data to send to Slack from this GitHub Action and either source:
-
-- The default event [context](https://github.com/actions/toolkit/blob/main/packages/github/src/context.ts#L6) with a [payload](https://docs.github.com/en/webhooks/webhook-events-and-payloads) matching the GitHub event.
-- A custom payload with optional [variables](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables) provided in the GitHub Action step.
-
-These input options are valid for all techniques, but some techniques require specific constraints with certain requirements for valid inputs.
-
-Additional [configurations](/slack-github-action/additional-configurations) and other details are also available for more customizations to the provided payload.
-
 ## Versioning
 
 We recommend using the latest version of this GitHub Action for the most recent updates and fixes.


### PR DESCRIPTION
### Summary

The homepage should be a home page not a home and topic page. now this topic is on a page.

We're immediately testing the worst edge case -- the resulting PR in the docusaurus repo will need to be modified to add the page to `sidebar.js`. Not too cumbersome to do via web client though

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).