### PR TITLE
chore(release): tag version 2.1.0

### DIFF
--- a/docs/additional-configurations.md
+++ b/docs/additional-configurations.md
@@ -10,7 +10,7 @@ The `errors` option defaults to `false` so failed requests do not cause the step
 
 ```yaml
 - name: Attempt to call an unknown method
-  uses: slackapi/slack-github-action@v2.0.0
+  uses: slackapi/slack-github-action@v2.1.0
   with:
     errors: true
     method: chat.reverse
@@ -29,7 +29,7 @@ The `payload-delimiter` option will flatten the input payload using the provided
 
 ```yaml
 - name: Flatten the default GitHub payload
-  uses: slackapi/slack-github-action@v2.0.0
+  uses: slackapi/slack-github-action@v2.1.0
   with:
     payload-delimiter: "_"
     webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -44,7 +44,7 @@ Additional variables provided in the GitHub event [context](https://github.com/a
 
 ```yaml
 - name: Send custom JSON data to Slack workflow
-  uses: slackapi/slack-github-action@v2.0.0
+  uses: slackapi/slack-github-action@v2.1.0
   with:
     payload-file-path: "./payload-slack-content.json"
     payload-templated: true
@@ -60,7 +60,7 @@ If you need to use a proxy to connect to Slack, you can use the `proxy` option. 
 
 ```yaml
 - name: Post to a Slack channel via a proxy
-  uses: slackapi/slack-github-action@v2.0.0
+  uses: slackapi/slack-github-action@v2.1.0
   with:
     method: chat.postMessage
     proxy: "http://proxy.example.org:8080" # Change this to a custom value
@@ -85,7 +85,7 @@ The `retries` option can be configured to the needs of your workflow with one of
 
 ```yaml
 - name: Attempt a burst of requests
-  uses: slackapi/slack-github-action@v2.0.0
+  uses: slackapi/slack-github-action@v2.1.0
   with:
     method: chat.postMessage
     retries: RAPID
@@ -103,7 +103,7 @@ In certain circumstances, such as testing the sent payload, a [custom API URL](h
 
 ```yaml
 - name: Send to a custom API URL
-  uses: slackapi/slack-github-action@v2.0.0
+  uses: slackapi/slack-github-action@v2.1.0
   with:
     api: http://localhost:8080
     method: chat.postMessage

--- a/docs/sending-techniques/sending-data-slack-api-method/sending-data-slack-api-method.md
+++ b/docs/sending-techniques/sending-data-slack-api-method/sending-data-slack-api-method.md
@@ -29,7 +29,7 @@ Posting a message with the [`chat.postMessage`](https://docs.slack.dev/reference
 
 ```yaml
 - name: Post text to a Slack channel
-  uses: slackapi/slack-github-action@v2.0.0
+  uses: slackapi/slack-github-action@v2.1.0
   with:
     method: chat.postMessage
     token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -44,7 +44,7 @@ More complex message layouts, such as messages made with [Block Kit](https://doc
 
 ```yaml
 - name: Post blocks to a Slack channel
-  uses: slackapi/slack-github-action@v2.0.0
+  uses: slackapi/slack-github-action@v2.1.0
   with:
     method: chat.postMessage
     token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -65,7 +65,7 @@ Updating a message after it's posted can be done with the [`chat.update`](https:
 ```yaml
 - name: Initiate the deployment launch sequence
   id: launch_sequence
-  uses: slackapi/slack-github-action@v2.0.0
+  uses: slackapi/slack-github-action@v2.1.0
   with:
     method: chat.postMessage
     token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -81,7 +81,7 @@ Updating a message after it's posted can be done with the [`chat.update`](https:
 - name: Countdown until launch
   run: sleep 10
 - name: Update the original message with success
-  uses: slackapi/slack-github-action@v2.0.0
+  uses: slackapi/slack-github-action@v2.1.0
   with:
     method: chat.update
     token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -103,7 +103,7 @@ Posting [threaded replies to a message](https://docs.slack.dev/messaging/#thread
 
 ```yaml
 - name: Initiate a deployment
-  uses: slackapi/slack-github-action@v2.0.0
+  uses: slackapi/slack-github-action@v2.1.0
   id: deployment_message
   with:
     method: chat.postMessage
@@ -112,7 +112,7 @@ Posting [threaded replies to a message](https://docs.slack.dev/messaging/#thread
       channel: ${{ secrets.SLACK_CHANNEL_ID }}
       text: "Deployment started :eyes:"
 - name: Conclude the deployment
-  uses: slackapi/slack-github-action@v2.0.0
+  uses: slackapi/slack-github-action@v2.1.0
   with:
     method: chat.postMessage
     token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -128,7 +128,7 @@ Calling [a Slack API method](https://docs.slack.dev/reference/methods) with [`@s
 
 ```yaml
 - name: Share a file to that channel
-  uses: slackapi/slack-github-action@v2.0.0
+  uses: slackapi/slack-github-action@v2.1.0
   with:
     method: files.uploadV2
     token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/docs/sending-techniques/sending-data-slack-incoming-webhook/sending-data-slack-incoming-webhook.md
+++ b/docs/sending-techniques/sending-data-slack-incoming-webhook/sending-data-slack-incoming-webhook.md
@@ -31,7 +31,7 @@ Add the collected webhook from above to a GitHub workflow and configure the step
 
 ```yaml
 - name: Post a message in a channel
-  uses: slackapi/slack-github-action@v2.0.0
+  uses: slackapi/slack-github-action@v2.1.0
   with:
     webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
     webhook-type: incoming-webhook

--- a/docs/sending-techniques/sending-data-webhook-slack-workflow/sending-data-webhook-slack-workflow.md
+++ b/docs/sending-techniques/sending-data-webhook-slack-workflow/sending-data-webhook-slack-workflow.md
@@ -34,7 +34,7 @@ In the example below, the default GitHub event [context](https://github.com/acti
 
 ```yaml
 - name: Send GitHub Action data to a Slack workflow
-  uses: slackapi/slack-github-action@v2.0.0
+  uses: slackapi/slack-github-action@v2.1.0
   with:
     payload-delimiter: "_"
     webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -49,7 +49,7 @@ Provided input values for payload information are sent to the webhook URL after 
 
 ```yaml
 - name: Send custom event details to a Slack workflow
-  uses: slackapi/slack-github-action@v2.0.0
+  uses: slackapi/slack-github-action@v2.1.0
   with:
     webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
     webhook-type: webhook-trigger
@@ -64,7 +64,7 @@ Input values for the payload to be sent can also be provided in a file, either i
 
 ```yaml
 - name: Send a saved artifact to a Slack workflow
-  uses: slackapi/slack-github-action@v2.0.0
+  uses: slackapi/slack-github-action@v2.1.0
   with:
     payload-file-path: "./artifacts.json"
     webhook: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/docs/sending-techniques/sending-techniques.md
+++ b/docs/sending-techniques/sending-techniques.md
@@ -37,7 +37,7 @@ The following snippet shows how multiple steps can be chained together to create
 ```yaml
 - name: Create a new Slack channel for recent changes
   id: conversation
-  uses: slackapi/slack-github-action@v2.0.0
+  uses: slackapi/slack-github-action@v2.1.0
   with:
     method: conversations.create
     token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -45,7 +45,7 @@ The following snippet shows how multiple steps can be chained together to create
       name: pull-request-review-${{ github.sha }}
 - name: Send the pull request link into the Slack channel
   if: ${{ steps.conversation.outputs.ok }}
-  uses: slackapi/slack-github-action@v2.0.0
+  uses: slackapi/slack-github-action@v2.1.0
   with:
     method: chat.postMessage
     token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/example-workflows/Technique_1_Slack_Workflow_Builder/announcements.gha.yml
+++ b/example-workflows/Technique_1_Slack_Workflow_Builder/announcements.gha.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Draft with these release notes details
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v2.1.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: webhook-trigger

--- a/example-workflows/Technique_1_Slack_Workflow_Builder/builds.gha.yml
+++ b/example-workflows/Technique_1_Slack_Workflow_Builder/builds.gha.yml
@@ -16,7 +16,7 @@ jobs:
           persist-credentials: false
 
       - name: Start the Slack workflow
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v2.1.0
         with:
           payload-file-path: "./example-workflows/Technique_1_Slack_Workflow_Builder/builds.data.json"
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/example-workflows/Technique_1_Slack_Workflow_Builder/topic.gha.yml
+++ b/example-workflows/Technique_1_Slack_Workflow_Builder/topic.gha.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update the channel topic
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v2.1.0
         with:
           payload-delimiter: "_"
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/example-workflows/Technique_2_Slack_API_Method/author.yml
+++ b/example-workflows/Technique_2_Slack_API_Method/author.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Find correspondences
         id: email
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v2.1.0
         with:
           method: users.lookupByEmail # https://api.slack.com/methods/users.lookupByEmail
           token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -30,7 +30,7 @@ jobs:
 
       - name: Send a direct message
         if: ${{ steps.email.outputs.ok }}
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v2.1.0
         with:
           errors: true
           method: chat.postMessage # https://api.slack.com/methods/chat.postMessage

--- a/example-workflows/Technique_2_Slack_API_Method/invite.yml
+++ b/example-workflows/Technique_2_Slack_API_Method/invite.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Create a new Slack channel for communications
         id: conversation
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v2.1.0
         with:
           errors: true
           method: conversations.create # https://api.slack.com/methods/conversations.create
@@ -22,7 +22,7 @@ jobs:
             name: issue-${{ github.event.issue.number }}
 
       - name: Send the issue link into the Slack channel
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v2.1.0
         with:
           method: chat.postMessage # https://api.slack.com/methods/chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -32,7 +32,7 @@ jobs:
 
       - name: Gather information of those to add
         id: members
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v2.1.0
         with:
           errors: true
           method: usergroups.users.list # https://api.slack.com/methods/usergroups.users.list
@@ -46,7 +46,7 @@ jobs:
           echo "SLACK_USERGROUP_USER_IDS=$SLACK_USERGROUP_USER_IDS" >> $GITHUB_ENV
 
       - name: Add the usergroup to the channel
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v2.1.0
         with:
           errors: true
           method: conversations.invite # https://api.slack.com/methods/conversations.invite

--- a/example-workflows/Technique_3_Slack_Incoming_Webhook/blocks.yml
+++ b/example-workflows/Technique_3_Slack_Incoming_Webhook/blocks.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Write the review
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v2.1.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/example-workflows/Technique_3_Slack_Incoming_Webhook/saved.gha.yml
+++ b/example-workflows/Technique_3_Slack_Incoming_Webhook/saved.gha.yml
@@ -16,7 +16,7 @@ jobs:
           persist-credentials: false
 
       - name: Forward a saved message
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v2.1.0
         with:
           payload-file-path: "./example-workflows/Technique_3_Slack_Incoming_Webhook/saved.data.json"
           payload-templated: true

--- a/example-workflows/Technique_3_Slack_Incoming_Webhook/text.yml
+++ b/example-workflows/Technique_3_Slack_Incoming_Webhook/text.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Greet the reader
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v2.1.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "slack-github-action",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "slack-github-action",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slack-github-action",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "The official Slack Github Action. Use this to send data into your Slack workspace",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
### Summary

This PR tags the latest changes on `main` as version 2.1.0. This includes the milestones:

- `2.1`: https://github.com/slackapi/slack-github-action/milestone/17
- `2.0.1`: https://github.com/slackapi/slack-github-action/milestone/16

Which will soon be moved to `2.1`! Full changelog: https://github.com/slackapi/slack-github-action/compare/v2.0.0...ab965e58bdca6c60639a701a79d306baf0cefd65

### Notes

- Hoping to follow up with a [`MAINTAINERS_GUIDE.md`](https://github.com/slackapi/slack-github-action/blob/main/.github/maintainers_guide.md#releasing) change to include changes to `package-lock.json` and related labels 🙏 ✨ 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).