### PR TITLE
ci: pin action hashes and escape variables with minimum permission

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -8,13 +8,15 @@ on:
 jobs:
   run:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout action
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
       - name: Setup the Node runtime for this project
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           cache: npm
           cache-dependency-path: package-lock.json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,13 +12,13 @@ jobs:
       contents: write
     steps:
       - name: Checkout the current code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
           ref: ${{ github.event.release.tag_name }}
 
       - name: Configure the runtime node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           cache: npm
           cache-dependency-path: package-lock.json
@@ -31,7 +31,7 @@ jobs:
         run: npm run build
 
       - name: Distribute the latest tagged release
-        uses: teunmooij/github-versioned-release@v1.2.1
+        uses: teunmooij/github-versioned-release@3edf649c6e5e5e976d43f2584b15bdc8b4c8f0df # v1.2.1
         with:
           template: javascript-action
         env:

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -5,28 +5,32 @@ on:
     branches:
       - main
     paths:
-      - "docs/**" 
+      - "docs/**"
   workflow_dispatch:
 
 jobs:
   config-sync:
     name: Sync docs to docs site repo
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Generate a GitHub token
         id: ghtoken
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         with:
           app-id: ${{ secrets.GH_APP_ID }}
           owner: slackapi
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - name: Checkout the tool repo (source)
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Checkout the docs site repo (destination)
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: slackapi/slackapi.github.io
           path: "docs_repo"
@@ -35,7 +39,9 @@ jobs:
 
       - name: Update docs in docs site repo
         run: |
-            rsync -av --delete ./docs/ ./docs_repo/content/${{ github.event.repository.name }}/
+          rsync -av --delete ./docs/ "./docs_repo/content/$REPO/"
+        env:
+          REPO: ${{ github.event.repository.name }}
 
       - name: Install dependencies
         run: |
@@ -50,7 +56,7 @@ jobs:
       - name: Create a pull request
         if: ${{ github.event.pull_request.merged || github.event_name == 'workflow_dispatch' }}
         id: site-pr
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           token: ${{ steps.ghtoken.outputs.token }}
           title: "From ${{ github.event.repository.name }}: ${{ github.event.pull_request.title || 'manual docs sync' }}"
@@ -66,4 +72,6 @@ jobs:
       - name: Output the pull request link
         if: ${{ steps.site-pr.outputs.pull-request-url }}
         run: |
-          echo "Pull request created: ${{ steps.site-pr.outputs.pull-request-url }}" >> $GITHUB_STEP_SUMMARY
+          echo "Pull request created: $URL" >> $GITHUB_STEP_SUMMARY
+        env:
+          URL: ${{ steps.site-pr.outputs.pull-request-url }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Tests
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
   push:
     branches:
       - main
@@ -15,13 +15,13 @@ jobs:
       checks: write
     steps:
       - name: "build: checkout the latest changes"
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: "build: setup the node runtime"
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           cache: npm
           cache-dependency-path: package-lock.json
@@ -40,7 +40,7 @@ jobs:
         run: npm test
 
       - name: "unit(test): upload coverage to CodeCov"
-        uses: codecov/codecov-action@v5.4.2
+        uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d # v5.4.2
         with:
           directory: ./coverage
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -50,15 +50,19 @@ jobs:
 
       - name: "pretest(inputs): save the push event trigger commit URL"
         if: "contains(github.event_name, 'push')"
+        id: push
         run: |
-          url=${{ github.event.head_commit.url }}
-          echo "EVENT_URL=$url" >> "$GITHUB_ENV"
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+        env:
+          URL: ${{ github.event.head_commit.url }}
 
       - name: "pretest(inputs): save the pull request event trigger commit URL"
         if: "contains(github.event_name, 'pull_request')"
+        id: pull_request
         run: |
-          url=${{ github.event.pull_request.html_url }}
-          echo "EVENT_URL=$url" >> "$GITHUB_ENV"
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+        env:
+          URL: ${{ github.event.pull_request.html_url }}
 
       - name: "integration(wfb): send a payload to workflow builder via webhook trigger"
         id: wfb
@@ -70,12 +74,14 @@ jobs:
           payload: |
             author: ${{ github.event.sender.login }}
             channel_id: ${{ secrets.SLACK_CHANNEL_ID }}
-            event_url: ${{ env.EVENT_URL}}
+            event_url: ${{ steps.push.outputs.url || steps.pull_request.outputs.url }}
             repo_name: ${{ github.event.repository.full_name }}
             status: ${{ job.status }}
 
       - name: "integration(wfb): confirm a payload was sent"
-        run: test -n "${{ steps.wfb.outputs.time }}"
+        run: test -n "$WFB_OUTPUT_TIME"
+        env:
+          WFB_OUTPUT_TIME: ${{ steps.wfb.outputs.time }}
 
       - name: "integration(botToken): post a message to channel"
         id: message
@@ -89,7 +95,9 @@ jobs:
             text: ":checkered_flag: Action happens at <https://github.com/${{ github.repository }}>"
 
       - name: "integration(method): confirm a message was posted"
-        run: test -n "${{ steps.message.outputs.ts }}"
+        run: test -n "$MESSAGE_OUTPUT_TS"
+        env:
+          MESSAGE_OUTPUT_TS: ${{ steps.message.outputs.ts }}
 
       - name: "integration(method): post a message with blocks"
         id: blocks
@@ -109,7 +117,9 @@ jobs:
                     value: "Processing"
 
       - name: "integration(method): confirm the blocks were posted"
-        run: test -n "${{ steps.blocks.outputs.ts }}"
+        run: test -n "$BLOCKS_OUTPUT_TS"
+        env:
+          BLOCKS_OUTPUT_TS: ${{ steps.blocks.outputs.ts }}
 
       - name: "integration(method): post a threaded message"
         id: timer
@@ -124,7 +134,9 @@ jobs:
             thread_ts: "${{ steps.blocks.outputs.ts }}"
 
       - name: "integration(incoming): confirm the thread started"
-        run: test -n "${{ steps.timer.outputs.time }}"
+        run: test -n "$TIMER_OUTPUT_TIME"
+        env:
+          TIMER_OUTPUT_TIME: ${{ steps.timer.outputs.time }}
 
       - name: "integration(method): wait to mock event processing"
         run: sleep 3
@@ -184,7 +196,9 @@ jobs:
             name: "tada"
 
       - name: "integration(method): confirm the thread ended"
-        run: test -n "${{ steps.done.outputs.time }}"
+        run: test -n "$DONE_OUTPUT_TIME"
+        env:
+          DONE_OUTPUT_TIME: ${{ steps.done.outputs.time }}
 
       - name: "integration(incoming): post a message via incoming webhook"
         id: incoming
@@ -203,10 +217,12 @@ jobs:
                   emoji: true
 
       - name: "integration(incoming): confirm a webhook was posted"
-        run: test -n "${{ steps.incoming.outputs.time }}"
+        run: test -n "$INCOMING_WEBHOOK_OUTPUT_TIME"
+        env:
+          INCOMING_WEBHOOK_OUTPUT_TIME: ${{ steps.incoming.outputs.time }}
 
       - name: "integration(incoming): reveal contents of the github payload"
-        run: echo $JSON
+        run: echo "$JSON"
         env:
           JSON: ${{ toJSON(github) }}
 
@@ -224,10 +240,12 @@ jobs:
           ATTACHMENT_COLOR: ${{ (job.status == 'success' && 'good') || (job.status == 'failure' && 'danger') || 'warning' }}
 
       - name: "integration(incoming): confirm a payload file was posted"
-        run: test -n "${{ steps.payload_file.outputs.time }}"
+        run: test -n "$PAYLOAD_FILE_OUTPUT_TIME"
+        env:
+          PAYLOAD_FILE_OUTPUT_TIME: ${{ steps.payload_file.outputs.time }}
 
       - name: "chore(health): check up on recent changes to the health score"
-        uses: slackapi/slack-health-score@v0.1.1
+        uses: slackapi/slack-health-score@d58a419f15cdaff97e9aa7f09f95772830ab66f7 # v0.1.1
         with:
           codecov_token: ${{ secrets.CODECOV_API_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Summary

This PR uses the wonderful [`zizmor`](https://github.com/zizmorcore/zizmor) tool to audit our own workflows and [`pinact`](https://github.com/suzuki-shunsuke/pinact) for pinned versioning 👾 

While not so simple to bump ourselves, the kind @dependabot can help keep these hashes updated with the changes of https://github.com/dependabot/dependabot-core/pull/5951 having landed 🤖 ✨

### Reviewers

A similar audit can be performed with the `zizmor` tool:

```sh
$ zizmor .
...
No findings to report. Good job! (1 ignored, 4 suppressed)
```

> The suppressed findings are expected permission blocks at the top-level of a workflow, but we set this for each job.

### Notes

Most changes I hope are repetitive, but I will comment on the more significant ones! FWIW the `develop` and `test` workflow continue to work with these changes:

- [`push`](https://github.com/zimeg/slack-github-action/actions/runs/15056293205/job/42322838794)
- [`pull_request`](https://github.com/zimeg/slack-github-action/pull/2#issuecomment-2885204635)

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).