### PR TITLE
docs: fix channel mention formatting

### DIFF
--- a/docs/sending-techniques/sending-data-slack-api-method/sending-data-slack-api-method.md
+++ b/docs/sending-techniques/sending-data-slack-api-method/sending-data-slack-api-method.md
@@ -35,7 +35,7 @@ Posting a message with the [`chat.postMessage`](https://docs.slack.dev/reference
     token: ${{ secrets.SLACK_BOT_TOKEN }}
     payload: |
       channel: ${{ secrets.SLACK_CHANNEL_ID }}
-      text: "howdy <@channel>!"
+      text: "howdy <!channel>!"
 ```
 
 ### Posting a message with blocks


### PR DESCRIPTION
### Summary

This pull request closes https://github.com/slackapi/slack-github-action/issues/446 by updating the docs to use `<!channel>` instead of `<@channel>` when mentioning the channel. [See special formatting documentation](https://api.slack.com/reference/surfaces/formatting#special-mentions).

Big thanks to @jacklu97 for reporting this issue! 🙇🏻 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).