### PR TITLE
build: create separate release branches for tagged releases on publish

### DIFF
--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -60,6 +60,8 @@ As a maintainer, the development you do will be almost entirely off of your fork
 
 `main` is where active development occurs.
 
+`release/vX.Y.Z` has the packaged distribution of a particular version based from the changes on `main`. This is created using a workflow when new releases are published.
+
 When developing, branches should be created off of your fork and not directly off of this repository. If working on a long-running feature and in collaboration with others, a corresponding branch of the same name is permitted. This makes collaboration on a single branch possible, as contributors working on the same feature cannot push commits to others' open Pull Requests.
 
 After a major version increment, there also may be maintenance branches created specifically for supporting older major versions.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,7 @@ jobs:
 
       - name: Create a branch for tagged release
         run:
+          git fetch origin "$SHA"
           git checkout -b "release/$TAG" "$SHA"
           git push origin "release/$TAG"
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,9 @@ name: Publish
 
 on:
   release:
-    types: [published, edited]
+    types: 
+      - published
+      - edited
 
 jobs:
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Create a branch for tagged release
-        run:
+        run: |
           git fetch origin "$SHA"
           git checkout -b "release/$TAG" "$SHA"
           git push origin "release/$TAG"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,7 @@ jobs:
       - name: Checkout the current code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          fetch-depth: 0
           persist-credentials: false
           ref: ${{ github.event.release.tag_name }}
 
@@ -31,8 +32,17 @@ jobs:
         run: npm run build
 
       - name: Distribute the latest tagged release
+        id: tag
         uses: teunmooij/github-versioned-release@3edf649c6e5e5e976d43f2584b15bdc8b4c8f0df # v1.2.1
         with:
           template: javascript-action
         env:
           GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Create a branch for tagged release
+        run:
+          git checkout -b "release/$TAG" "$SHA"
+          git push origin "release/$TAG"
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          SHA: ${{ steps.tag.outputs.sha }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true
           ref: ${{ github.event.release.tag_name }}
 
       - name: Configure the runtime node


### PR DESCRIPTION
### Summary

This PR creates separate release branches for tagged releases from the changes on `main` to avoid appearances of the confusing "imposter commit". Fixes #444.

### Preview

Release candidates with these attempted changes can be found from a fork:

- https://github.com/zimeg/slack-github-action/releases/tag/v2.1.1-rc.6

Notice that https://github.com/zimeg/slack-github-action/commit/9dd078e82245b6abf6ecca61735ab0d2699bc890 is part of the [`v2.1.1-rc.6`](https://github.com/zimeg/slack-github-action/releases/tag/v2.1.1-rc.6) release branch while an earlier commit for [`v2.1.1-rc.1`](https://github.com/zimeg/slack-github-action/releases/tag/v2.1.1-rc.1) is shown as https://github.com/zimeg/slack-github-action/commit/91855720aaee2e23bf81dae3512204a371ca1609 and contains the warning:

> ⚠️ This commit does not belong to any branch on this repository, and may belong to a fork outside of the repository.

### Notes

The release branch pattern is of course open for discussion! But for fast reference it appears as:

- `release/v2.1.0`
- `release/v2.1.1-rc.1`
- `release/v2.1.1`
- `release/v2.2.0`

Separate branches are preferred to including the packaged distribution on `main` and are also required since tags do not share direct histories:

```sh
*-----*-----*-----*-----*-----*-----*-----*-----* (main)
 \                 \                       \
  *                 *                       *
  v2.0.0            v2.1.0-rc1              v2.1.0
  v2.0                                      v2.1
                                            v2

 (release/v2.0.0)  (release/v2.1.0-rc.1)   (release/v2.1.0)
```

📣 If these changes seem alright I plan to create similar release branches for releases since `@v2`!

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).