### PR TITLE
Docs: updates links to point to `docs.slack.dev/tools*` paths

### DIFF
--- a/docs/_sidebar.json
+++ b/docs/_sidebar.json
@@ -1,34 +1,34 @@
 [
     {
       "type": "doc",
-      "id": "slack-github-action/slack-github-action",
+      "id": "tools/slack-github-action/tools/slack-github-action",
       "label": "Slack GitHub Action",
       "className": "sidebar-title"
     },
     { "type": "html", "value": "<hr>" },
-    "slack-github-action/sending-variables",
+    "tools/slack-github-action/sending-variables",
     {
       "type": "category",
       "label": "Sending techniques",
       "collapsed": false,
       "link": {
         "type": "doc",
-        "id": "slack-github-action/sending-techniques/sending-techniques"
+        "id": "tools/slack-github-action/sending-techniques/sending-techniques"
       },
       "items": [
-        "slack-github-action/sending-techniques/sending-techniques",
+        "tools/slack-github-action/sending-techniques/sending-techniques",
         {
           "type": "category",
           "label": "Sending data via a webhook to start a Slack workflow",
           "link": {
             "type": "doc",
-            "id": "slack-github-action/sending-techniques/sending-data-webhook-slack-workflow/sending-data-webhook-slack-workflow"
+            "id": "tools/slack-github-action/sending-techniques/sending-data-webhook-slack-workflow/sending-data-webhook-slack-workflow"
           },
           "items": [
-            "slack-github-action/sending-techniques/sending-data-webhook-slack-workflow/sending-data-webhook-slack-workflow",
-            "slack-github-action/sending-techniques/sending-data-webhook-slack-workflow/format-generated-files",
-            "slack-github-action/sending-techniques/sending-data-webhook-slack-workflow/post-release-announcements",
-            "slack-github-action/sending-techniques/sending-data-webhook-slack-workflow/update-a-channel-topic"
+            "tools/slack-github-action/sending-techniques/sending-data-webhook-slack-workflow/sending-data-webhook-slack-workflow",
+            "tools/slack-github-action/sending-techniques/sending-data-webhook-slack-workflow/format-generated-files",
+            "tools/slack-github-action/sending-techniques/sending-data-webhook-slack-workflow/post-release-announcements",
+            "tools/slack-github-action/sending-techniques/sending-data-webhook-slack-workflow/update-a-channel-topic"
           ]
         },
         {
@@ -36,12 +36,12 @@
           "label": "Sending data using a Slack API method",
           "link": {
             "type": "doc",
-            "id": "slack-github-action/sending-techniques/sending-data-slack-api-method/sending-data-slack-api-method"
+            "id": "tools/slack-github-action/sending-techniques/sending-data-slack-api-method/sending-data-slack-api-method"
           },
           "items": [
-            "slack-github-action/sending-techniques/sending-data-slack-api-method/sending-data-slack-api-method",
-            "slack-github-action/sending-techniques/sending-data-slack-api-method/direct-message-author",
-            "slack-github-action/sending-techniques/sending-data-slack-api-method/invite-usergroup-to-channel"
+            "tools/slack-github-action/sending-techniques/sending-data-slack-api-method/sending-data-slack-api-method",
+            "tools/slack-github-action/sending-techniques/sending-data-slack-api-method/direct-message-author",
+            "tools/slack-github-action/sending-techniques/sending-data-slack-api-method/invite-usergroup-to-channel"
           ]
         },
         {
@@ -49,16 +49,16 @@
           "label": "Sending data as a message with a Slack incoming webhook URL",
           "link": {
             "type": "doc",
-            "id": "slack-github-action/sending-techniques/sending-data-slack-incoming-webhook/sending-data-slack-incoming-webhook"
+            "id": "tools/slack-github-action/sending-techniques/sending-data-slack-incoming-webhook/sending-data-slack-incoming-webhook"
           },
           "items": [
-            "slack-github-action/sending-techniques/sending-data-slack-incoming-webhook/sending-data-slack-incoming-webhook",
-            "slack-github-action/sending-techniques/sending-data-slack-incoming-webhook/post-inline-text-message",
-            "slack-github-action/sending-techniques/sending-data-slack-incoming-webhook/post-inline-block-message",
-            "slack-github-action/sending-techniques/sending-data-slack-incoming-webhook/post-blocks-found-in-file"
+            "tools/slack-github-action/sending-techniques/sending-data-slack-incoming-webhook/sending-data-slack-incoming-webhook",
+            "tools/slack-github-action/sending-techniques/sending-data-slack-incoming-webhook/post-inline-text-message",
+            "tools/slack-github-action/sending-techniques/sending-data-slack-incoming-webhook/post-inline-block-message",
+            "tools/slack-github-action/sending-techniques/sending-data-slack-incoming-webhook/post-blocks-found-in-file"
           ]
         }
       ]
     },
-    "slack-github-action/additional-configurations"
+    "tools/slack-github-action/additional-configurations"
   ] 

--- a/docs/_sidebar.json
+++ b/docs/_sidebar.json
@@ -1,7 +1,7 @@
 [
     {
       "type": "doc",
-      "id": "tools/slack-github-action/tools/slack-github-action",
+      "id": "tools/slack-github-action/slack-github-action",
       "label": "Slack GitHub Action",
       "className": "sidebar-title"
     },

--- a/docs/additional-configurations.md
+++ b/docs/additional-configurations.md
@@ -23,7 +23,7 @@ Invalid inputs to the GitHub Action, such as not including a payload, will alway
 
 ## Flattening nested payloads
 
-Variables and data provided in the payload might contain nested fields that need to be flattened before being sent with a [webhook trigger](/slack-github-action/sending-techniques/sending-data-webhook-slack-workflow) to match the expected input format of [Workflow Builder](https://slack.com/features/workflow-automation).
+Variables and data provided in the payload might contain nested fields that need to be flattened before being sent with a [webhook trigger](/tools/slack-github-action/sending-techniques/sending-data-webhook-slack-workflow) to match the expected input format of [Workflow Builder](https://slack.com/features/workflow-automation).
 
 The `payload-delimiter` option will flatten the input payload using the provided delimiter and will also make values stringified:
 

--- a/docs/sending-techniques/sending-data-slack-api-method/sending-data-slack-api-method.md
+++ b/docs/sending-techniques/sending-data-slack-api-method/sending-data-slack-api-method.md
@@ -141,5 +141,5 @@ Calling [a Slack API method](https://docs.slack.dev/reference/methods) with [`@s
 
 ## Example workflows
 
-* [**Direct message the author**](/slack-github-action/sending-techniques/sending-data-slack-api-method/direct-message-author): Write to the Slack user with a matching email.
-* [**Invite a usergroup to channel**](/slack-github-action/sending-techniques/sending-data-slack-api-method/invite-usergroup-to-channel): Create a channel and invite members.
+* [**Direct message the author**](/tools/slack-github-action/sending-techniques/sending-data-slack-api-method/direct-message-author): Write to the Slack user with a matching email.
+* [**Invite a usergroup to channel**](/tools/slack-github-action/sending-techniques/sending-data-slack-api-method/invite-usergroup-to-channel): Create a channel and invite members.

--- a/docs/sending-techniques/sending-data-slack-incoming-webhook/sending-data-slack-incoming-webhook.md
+++ b/docs/sending-techniques/sending-data-slack-incoming-webhook/sending-data-slack-incoming-webhook.md
@@ -46,6 +46,6 @@ Add the collected webhook from above to a GitHub workflow and configure the step
 
 ## Example workflows
 
-* [**Post an inline text message**](/slack-github-action/sending-techniques/sending-data-slack-incoming-webhook/post-inline-text-message)
-* [**Post an inline block message**](/slack-github-action/sending-techniques/sending-data-slack-incoming-webhook/post-inline-block-message)
-* [**Post blocks found in a file**](/slack-github-action/sending-techniques/sending-data-slack-incoming-webhook/post-blocks-found-in-file)
+* [**Post an inline text message**](/tools/slack-github-action/sending-techniques/sending-data-slack-incoming-webhook/post-inline-text-message)
+* [**Post an inline block message**](/tools/slack-github-action/sending-techniques/sending-data-slack-incoming-webhook/post-inline-block-message)
+* [**Post blocks found in a file**](/tools/slack-github-action/sending-techniques/sending-data-slack-incoming-webhook/post-blocks-found-in-file)

--- a/docs/sending-techniques/sending-data-webhook-slack-workflow/sending-data-webhook-slack-workflow.md
+++ b/docs/sending-techniques/sending-data-webhook-slack-workflow/sending-data-webhook-slack-workflow.md
@@ -41,7 +41,7 @@ In the example below, the default GitHub event [context](https://github.com/acti
     webhook-type: webhook-trigger
 ```
 
-Accessing variables sent to [Workflow Builder](https://slack.com/features/workflow-automation) with a webhook require that the payload variables are flattened with stringified values. Nested variables in the provided payload can be both flattened and also stringified with the `payload-delimiter` option or changed with other [configurations](/slack-github-action/additional-configurations) to match this format expected from Workflow Builder.
+Accessing variables sent to [Workflow Builder](https://slack.com/features/workflow-automation) with a webhook require that the payload variables are flattened with stringified values. Nested variables in the provided payload can be both flattened and also stringified with the `payload-delimiter` option or changed with other [configurations](/tools/slack-github-action/additional-configurations) to match this format expected from Workflow Builder.
 
 ### Providing parsed payload information as strings
 
@@ -73,6 +73,6 @@ Input values for the payload to be sent can also be provided in a file, either i
 
 ## Example workflows
 
-* [**Format generated files**](/slack-github-action/sending-techniques/sending-data-webhook-slack-workflow/format-generated-files): Message outputs from prior steps.
-* [**Post release announcements**](/slack-github-action/sending-techniques/sending-data-webhook-slack-workflow/post-release-announcements): Share releases to a channel.
-* [**Update a channel topic**](/slack-github-action/sending-techniques/sending-data-webhook-slack-workflow/update-a-channel-topic): Highlight the current build status.
+* [**Format generated files**](/tools/slack-github-action/sending-techniques/sending-data-webhook-slack-workflow/format-generated-files): Message outputs from prior steps.
+* [**Post release announcements**](/tools/slack-github-action/sending-techniques/sending-data-webhook-slack-workflow/post-release-announcements): Share releases to a channel.
+* [**Update a channel topic**](/tools/slack-github-action/sending-techniques/sending-data-webhook-slack-workflow/update-a-channel-topic): Highlight the current build status.

--- a/docs/sending-techniques/sending-techniques.md
+++ b/docs/sending-techniques/sending-techniques.md
@@ -6,9 +6,9 @@ sidebar_label: Overview
 
 This GitHub Action offers three different techniques to send data to Slack:
 
-* [Send data with a webhook to start a workflow in Workflow Builder](/slack-github-action/sending-techniques/sending-data-webhook-slack-workflow).
-* [Send data using a Slack API method and a secret token with required scopes](/slack-github-action/sending-techniques/sending-data-slack-api-method/).
-* [Send data as a message with a Slack incoming webhook URL](/slack-github-action/sending-techniques/sending-data-slack-incoming-webhook/). 
+* [Send data with a webhook to start a workflow in Workflow Builder](/tools/slack-github-action/sending-techniques/sending-data-webhook-slack-workflow).
+* [Send data using a Slack API method and a secret token with required scopes](/tools/slack-github-action/sending-techniques/sending-data-slack-api-method/).
+* [Send data as a message with a Slack incoming webhook URL](/tools/slack-github-action/sending-techniques/sending-data-slack-incoming-webhook/). 
 
 ## Expected outputs
 

--- a/docs/sending-variables.md
+++ b/docs/sending-variables.md
@@ -1,6 +1,6 @@
 # Sending variables
 
-There are different [techniques to send data](/slack-github-action/sending-techniques) into Slack and whichever one is chosen will require a certain set of customized inputs, as described later.
+There are different [techniques to send data](/tools/slack-github-action/sending-techniques) into Slack and whichever one is chosen will require a certain set of customized inputs, as described later.
 
 You can provide data to send to Slack from this GitHub Action and either source:
 
@@ -9,4 +9,4 @@ You can provide data to send to Slack from this GitHub Action and either source:
 
 These input options are valid for all techniques, but some techniques require specific constraints with certain requirements for valid inputs.
 
-Additional [configurations](/slack-github-action/additional-configurations) and other details are also available for more customizations to the provided payload.
+Additional [configurations](/tools/slack-github-action/additional-configurations) and other details are also available for more customizations to the provided payload.


### PR DESCRIPTION
### Summary

tools pages are being directed to docs.slack.dev/tools moving forward. This readies the links for that

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).