### PR TITLE
Add Slack CLI command runner workflow and installer composite action

### DIFF
--- a/.github/resources/.actions/slack-cli-installer/action.yml
+++ b/.github/resources/.actions/slack-cli-installer/action.yml
@@ -1,0 +1,35 @@
+name: Slack CLI Installation
+description: Download and cache the Slack CLI 
+runs:
+  using: composite
+  steps:
+    - name: Cache Slack CLI
+      id: cache-cli
+      uses: actions/cache@v4
+      with:
+        path: ~/.slack/bin
+        key: slack-cli-${{ runner.os }}-${{ runner.arch }}-${{ env.SLACK_CLI_VERSION }}  
+
+    - name: Add Slack CLI to PATH (Linux/macOS)
+      if: runner.os != 'Windows'
+      shell: bash
+      run: echo "$HOME/.slack/bin" >> "$GITHUB_PATH"
+
+    - name: Add Slack CLI to PATH (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: Add-Content -Path $env:GITHUB_PATH -Value "$env:USERPROFILE\.slack\bin"
+
+    - name: Install Slack CLI (Linux/macOS)
+      if:
+        (runner.os == 'Linux' || runner.os == 'macOS') && steps.cache-cli.outputs.cache-hit != 'true' 
+      shell: bash
+      run:
+        curl -fsSL https://downloads.slack-edge.com/slack-cli/install.sh | bash -s -- -v $SLACK_CLI_VERSION
+
+    - name: Install Slack CLI (Windows)
+      if: runner.os == 'Windows' && steps.cache-cli.outputs.cache-hit != 'true'
+      shell: pwsh 
+      run: |
+        irm https://downloads.slack-edge.com/slack-cli/install-windows-dev.ps1 -OutFile 'install-windows-dev.ps1'
+        .\install-windows-dev.ps1 -Version $env:SLACK_CLI_VERSION

--- a/.github/workflows/slack-cli-command.yml
+++ b/.github/workflows/slack-cli-command.yml
@@ -1,0 +1,43 @@
+name: Slack CLI Command Runner
+
+on:
+  workflow_dispatch:
+    inputs:
+      command:
+        description: 'Slack CLI command to run'
+        required: true
+
+jobs:
+  deploy:
+    name: "Run Slack CLI command"
+    runs-on: ubuntu-latest
+    env: 
+      SLACK_CLI_VERSION: "3.5.2"
+    timeout-minutes: 10
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Slack CLI
+        uses: ./.github/resources/.actions/slack-cli-installer
+        
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: npm install shell-quote
+
+      - name: Execute command via script
+        run: | 
+            echo "Running command: ${{ github.event.inputs.command }}"
+            node src/parse-command.js ${{ github.event.inputs.command }}
+        env:
+          SLACK_SERVICE_TOKEN: ${{ secrets.SLACK_SERVICE_TOKEN }} 
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/src/parse-command.js
+++ b/src/parse-command.js
@@ -1,0 +1,30 @@
+const { parse: _parse } = require('shell-quote');
+const { execFile } = require('child_process');
+
+async function parse(rawInput) {
+  let tokens;
+  try {
+    tokens = _parse(rawInput);
+  } catch (err) {
+    throw Error("Invalid syntax: command contains at least one NULL character");
+  }
+
+  if (tokens.length === 0) {
+    throw Error("No command provided");
+  }
+
+  console.log('Executing the command:', tokens.join(' '));
+  const args = tokens.slice(1);
+
+  execFile('slack', args, (error, stdout) => {
+    if (error) {
+      throw Error(`Slack CLI Error: ${error.message}`);
+    }
+    console.log(stdout);  
+  });
+}
+
+if (require.main === module) {
+  const rawInput = process.argv.slice(2).join(' '); 
+  parse(rawInput);
+}


### PR DESCRIPTION
### Summary

This PR adds a new GitHub composite action and workflow that allows running Slack CLI commands directly.



### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).