### PR TITLE
feat: add Slack CLI command runner workflow and installer composite action

### DIFF
--- a/.github/resources/.actions/slack-cli-runner/action.yml
+++ b/.github/resources/.actions/slack-cli-runner/action.yml
@@ -1,0 +1,66 @@
+name: Slack CLI Installation and Command Runner 
+description: Download and cache the Slack CLI and run the input command 
+
+inputs:
+  command:
+    description: "Slack CLI command to run"
+    required: true
+  verbose:
+    description: "Enable verbose output"
+    required: false
+    default: 'false'
+  cli_version:
+    description: "Slack CLI Version"
+    required: false
+    default: '3.6.0'
+
+runs:
+  using: composite
+  steps:
+    - name: Cache Slack CLI 
+      id: cache-cli
+      uses: actions/cache@v4
+      with:
+        path: ~/.slack/bin
+        key: slack-cli-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cli_version }}
+
+    - name: Add Slack CLI to PATH (Linux/macOS)
+      if: runner.os != 'Windows'
+      shell: bash
+      run: echo "$HOME/.slack/bin" >> "$GITHUB_PATH"
+
+    - name: Add Slack CLI to PATH (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: Add-Content -Path $env:GITHUB_PATH -Value "$env:USERPROFILE\.slack\bin"
+
+    - name: Install Slack CLI (Linux/macOS)
+      if:
+        (runner.os == 'Linux' || runner.os == 'macOS') && 
+        (steps.cache-cli.outputs.cache-hit != 'true')
+      shell: bash
+      run: |
+        curl -fsSL https://downloads.slack-edge.com/slack-cli/install.sh | bash -s -- -v ${{ inputs.cli_version }} --skip-update
+
+    - name: Install Slack CLI (Windows)
+      if: 
+        runner.os == 'Windows' && 
+        (steps.cache-cli.outputs.cache-hit != 'true')
+      shell: pwsh 
+      run: |
+        irm https://downloads.slack-edge.com/slack-cli/install-windows-dev.ps1
+  
+    - name: Run Slack CLI Command
+      shell: bash
+      env:
+        SLACK_SERVICE_TOKEN: $SLACK_SERVICE_TOKEN
+        SLACK_BOT_TOKEN: $SLACK_BOT_TOKEN
+        VERBOSE: ${{ inputs.verbose }}
+      run: |
+        echo "Running command: ${{ inputs.command }}"
+        if [ "${{ inputs.verbose }}" == "true" ]; then
+          slack ${{ inputs.command }} --verbose --skip-update
+        else
+          slack ${{ inputs.command }} --skip-update
+        fi
+        

--- a/.github/workflows/slack-cli-github-action.yml
+++ b/.github/workflows/slack-cli-github-action.yml
@@ -1,0 +1,39 @@
+name: Slack CLI Command Runner
+
+on:
+  workflow_dispatch:
+    inputs:
+      command:
+        description: 'Slack CLI command to run'
+        required: true
+      verbose:
+        description: 'Verbose flag'
+        type: boolean
+        default: false
+      cli_version:
+        description: 'Slack CLI version'
+        required: false
+        default: "latest"
+
+env:
+  SLACK_DISABLE_TELEMETRY: "true"
+
+jobs:
+  deploy:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Slack CLI and Run Command
+        uses: ./.github/.actions/slack-cli-runner
+        with:
+          command: ${{ github.event.inputs.command }}
+          verbose: ${{ github.run_attempt > 1 }}
+          cli_version: ${{ github.event.inputs.cli_version }}
+        env:
+          SLACK_SERVICE_TOKEN: ${{ secrets.SLACK_SERVICE_TOKEN }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION

### Summary

This PR builds upon [#486](https://github.com/slackapi/slack-github-action/pull/486). It continues iterating on the GitHub composite action and workflow that runs Slack CLI commands directly in CI/CD. 

### Notes on Changes


Added action inputs for common flags including `verbose` and `CLI version`


Re-running a workflow automatically enables verbose output


Removed the flag-parsing script in favor of direct command execution via `slack ${{ inputs.command }}`


Added `--skip-update` flag to prevent auto-updates during installation


Enabled `SLACK_DISABLE_TELEMETRY` variable so usage won’t bump up numbers in collecting metrics


Updated logging to match GitHub's logger


Moved major logic into action.yml as a proper composite action


### Requirements 

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).