### PR TITLE
test: switch junit test reporter for lcov results to upload

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       - name: "unit(test): upload coverage to CodeCov"
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
-          files: test/coverage.xml
+          files: test/coverage.txt
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: "build: package code for distribution"

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ node_modules
 .DS_Store
 
 # Testing remnants
-coverage.xml
+coverage.txt

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "act public --eventpath .github/resources/.actions/event.json --secret-file .github/resources/.env --platform ubuntu-latest=node:20-buster --container-architecture linux/amd64",
     "lint:fix": "biome check --write",
     "lint": "biome check",
-    "test": "node --test --experimental-test-coverage --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=test/coverage.xml test/*.spec.js",
+    "test": "node --test --experimental-test-coverage --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=test/coverage.txt test/*.spec.js",
     "postversion": "TAG=\"v$(npm pkg get version | jq -r)\" && grep -rl 'slackapi/slack-github-action@v' ./docs ./example-workflows | xargs sed -i \"s|slackapi/slack-github-action@v.*|slackapi/slack-github-action@${TAG}|g\""
   },
   "repository": {


### PR DESCRIPTION
### Summary

This PR switches the `junit` test reporter for the `lcov` results to upload test coverage to the kind @codecov! Follows changes of #538 🤖 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).