### PR TITLE
build: use default node test runner for unit test mocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,9 +26,7 @@
         "@types/js-yaml": "^4.0.9",
         "@types/markup-js": "^1.5.0",
         "@types/node": "^20.19.30",
-        "@types/sinon": "^21.0.0",
         "@vercel/ncc": "^0.38.4",
-        "sinon": "^21.0.1",
         "typescript": "^5.9.3"
       },
       "engines": {
@@ -386,47 +384,6 @@
         "@octokit/openapi-types": "^27.0.0"
       }
     },
-    "node_modules/@sinonjs/commons": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
-      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "type-detect": "4.0.8"
-      }
-    },
-    "node_modules/@sinonjs/fake-timers": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.1.0.tgz",
-      "integrity": "sha512-cqfapCxwTGsrR80FEgOoPsTonoefMBY7dnUEbQ+GRcved0jvkJLzvX6F4WtN+HBqbPX/SiFsIRUp+IrCW/2I2w==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.1"
-      }
-    },
-    "node_modules/@sinonjs/samsam": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.3.tgz",
-      "integrity": "sha512-hw6HbX+GyVZzmaYNh82Ecj1vdGZrqVIn/keDTg63IgAwiQPO+xCz99uG6Woqgb4tM0mUiFENKZ4cqd7IX94AXQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.1",
-        "type-detect": "^4.1.0"
-      }
-    },
-    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
-      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@slack/logger": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-4.0.0.tgz",
@@ -508,23 +465,6 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/sinon": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-21.0.0.tgz",
-      "integrity": "sha512-+oHKZ0lTI+WVLxx1IbJDNmReQaIsQJjN2e7UUrJHEeByG7bFeKJYsv1E75JxTQ9QKJDp21bAa/0W2Xo4srsDnw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/sinonjs__fake-timers": "*"
-      }
-    },
-    "node_modules/@types/sinonjs__fake-timers": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
-      "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@vercel/ncc": {
@@ -632,16 +572,6 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/diff": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
-      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/dunder-proto": {
@@ -828,15 +758,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/has-symbols": {
@@ -1043,36 +964,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/sinon": {
-      "version": "21.0.1",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-21.0.1.tgz",
-      "integrity": "sha512-Z0NVCW45W8Mg5oC/27/+fCqIHFnW8kpkFOq0j9XJIev4Ld0mKmERaZv5DMLAb9fGCevjKwaEeIQz5+MBXfZcDw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.1",
-        "@sinonjs/fake-timers": "^15.1.0",
-        "@sinonjs/samsam": "^8.0.3",
-        "diff": "^8.0.2",
-        "supports-color": "^7.2.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/sinon"
-      }
-    },
-    "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/tunnel": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
@@ -1080,16 +971,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
-      }
-    },
-    "node_modules/type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -51,9 +51,7 @@
     "@types/js-yaml": "^4.0.9",
     "@types/markup-js": "^1.5.0",
     "@types/node": "^20.19.30",
-    "@types/sinon": "^21.0.0",
     "@vercel/ncc": "^0.38.4",
-    "sinon": "^21.0.1",
     "typescript": "^5.9.3"
   }
 }

--- a/test/client.spec.js
+++ b/test/client.spec.js
@@ -213,10 +213,7 @@ describe("client", () => {
       assert.deepEqual(mocks.calls.mock.calls[0].arguments[1], args);
       assert.equal(mocks.core.setOutput.mock.calls[0].arguments[0], "ok");
       assert.equal(mocks.core.setOutput.mock.calls[0].arguments[1], true);
-      assert.equal(
-        mocks.core.setOutput.mock.calls[1].arguments[0],
-        "response",
-      );
+      assert.equal(mocks.core.setOutput.mock.calls[1].arguments[0], "response");
       assert.equal(
         mocks.core.setOutput.mock.calls[1].arguments[1],
         JSON.stringify(response),
@@ -275,10 +272,7 @@ describe("client", () => {
       assert.deepEqual(mocks.calls.mock.calls[0].arguments[1], args);
       assert.equal(mocks.core.setOutput.mock.calls[0].arguments[0], "ok");
       assert.equal(mocks.core.setOutput.mock.calls[0].arguments[1], true);
-      assert.equal(
-        mocks.core.setOutput.mock.calls[1].arguments[0],
-        "response",
-      );
+      assert.equal(mocks.core.setOutput.mock.calls[1].arguments[0], "response");
       assert.equal(
         mocks.core.setOutput.mock.calls[1].arguments[1],
         JSON.stringify(response),
@@ -318,10 +312,7 @@ describe("client", () => {
       assert.deepEqual(mocks.calls.mock.calls[0].arguments[1], args);
       assert.equal(mocks.core.setOutput.mock.calls[0].arguments[0], "ok");
       assert.equal(mocks.core.setOutput.mock.calls[0].arguments[1], true);
-      assert.equal(
-        mocks.core.setOutput.mock.calls[1].arguments[0],
-        "response",
-      );
+      assert.equal(mocks.core.setOutput.mock.calls[1].arguments[0], "response");
       assert.equal(
         mocks.core.setOutput.mock.calls[1].arguments[1],
         JSON.stringify(response),
@@ -353,7 +344,10 @@ describe("client", () => {
         token: "xoxb-example",
         payload: `"text": "hello"`,
       };
-      mocks.calls._rejectsWith = errors.requestErrorWithOriginal(response, true);
+      mocks.calls._rejectsWith = errors.requestErrorWithOriginal(
+        response,
+        true,
+      );
       try {
         await send(mocks.core);
         assert.fail("Expected an error but none was found");

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -20,13 +20,19 @@ describe("config", () => {
 
   describe("inputs", () => {
     it("valid values are collected from the action inputs", async () => {
-      mocks.core.getInput.withArgs("api").returns("http://localhost:8080");
-      mocks.core.getBooleanInput.withArgs("errors").returns(true);
-      mocks.core.getInput.withArgs("method").returns("chat.postMessage");
-      mocks.core.getInput.withArgs("payload").returns('"hello": "world"');
-      mocks.core.getInput.withArgs("proxy").returns("https://example.com");
-      mocks.core.getInput.withArgs("retries").returns("0");
-      mocks.core.getInput.withArgs("token").returns("xoxb-example");
+      mocks.inputs = {
+        ...mocks.inputs,
+        api: "http://localhost:8080",
+        method: "chat.postMessage",
+        payload: '"hello": "world"',
+        proxy: "https://example.com",
+        retries: "0",
+        token: "xoxb-example",
+      };
+      mocks.booleanInputs = {
+        ...mocks.booleanInputs,
+        errors: true,
+      };
       const config = new Config(mocks.core);
       assert.equal(config.inputs.api, "http://localhost:8080");
       assert.equal(config.inputs.errors, true);
@@ -35,36 +41,65 @@ describe("config", () => {
       assert.equal(config.inputs.proxy, "https://example.com");
       assert.equal(config.inputs.retries, config.Retries.ZERO);
       assert.equal(config.inputs.token, "xoxb-example");
-      assert.ok(mocks.core.setSecret.withArgs("xoxb-example").called);
+      assert.ok(
+        mocks.core.setSecret.mock.calls.some(
+          (c) => c.arguments[0] === "xoxb-example",
+        ),
+      );
     });
 
     it("allows token environment variables with a webhook", async () => {
       process.env.SLACK_TOKEN = "xoxb-example";
-      mocks.core.getInput.withArgs("webhook").returns("https://example.com");
-      mocks.core.getInput.withArgs("webhook-type").returns("incoming-webhook");
+      mocks.inputs = {
+        ...mocks.inputs,
+        webhook: "https://example.com",
+        "webhook-type": "incoming-webhook",
+      };
       const config = new Config(mocks.core);
       assert.equal(config.inputs.token, "xoxb-example");
       assert.equal(config.inputs.webhook, "https://example.com");
       assert.equal(config.inputs.webhookType, "incoming-webhook");
-      assert.ok(mocks.core.setSecret.withArgs("xoxb-example").called);
-      assert.ok(mocks.core.setSecret.withArgs("https://example.com").called);
+      assert.ok(
+        mocks.core.setSecret.mock.calls.some(
+          (c) => c.arguments[0] === "xoxb-example",
+        ),
+      );
+      assert.ok(
+        mocks.core.setSecret.mock.calls.some(
+          (c) => c.arguments[0] === "https://example.com",
+        ),
+      );
     });
 
     it("allows webhook environment variables with a token", async () => {
       process.env.SLACK_WEBHOOK_URL = "https://example.com";
-      mocks.core.getInput.withArgs("method").returns("chat.postMessage");
-      mocks.core.getInput.withArgs("token").returns("xoxb-example");
+      mocks.inputs = {
+        ...mocks.inputs,
+        method: "chat.postMessage",
+        token: "xoxb-example",
+      };
       const config = new Config(mocks.core);
       assert.equal(config.inputs.method, "chat.postMessage");
       assert.equal(config.inputs.token, "xoxb-example");
       assert.equal(config.inputs.webhook, "https://example.com");
-      assert.ok(mocks.core.setSecret.withArgs("xoxb-example").called);
-      assert.ok(mocks.core.setSecret.withArgs("https://example.com").called);
+      assert.ok(
+        mocks.core.setSecret.mock.calls.some(
+          (c) => c.arguments[0] === "xoxb-example",
+        ),
+      );
+      assert.ok(
+        mocks.core.setSecret.mock.calls.some(
+          (c) => c.arguments[0] === "https://example.com",
+        ),
+      );
     });
 
     it("errors when both the token and webhook is provided", async () => {
-      mocks.core.getInput.withArgs("token").returns("xoxb-example");
-      mocks.core.getInput.withArgs("webhook").returns("https://example.com");
+      mocks.inputs = {
+        ...mocks.inputs,
+        token: "xoxb-example",
+        webhook: "https://example.com",
+      };
       try {
         new Config(mocks.core);
         assert.fail("Failed to error when invalid inputs are provided");
@@ -75,9 +110,15 @@ describe("config", () => {
               "Invalid input! Either the token or webhook is required - not both.",
             ),
           );
-          assert.ok(mocks.core.setSecret.withArgs("xoxb-example").called);
           assert.ok(
-            mocks.core.setSecret.withArgs("https://example.com").called,
+            mocks.core.setSecret.mock.calls.some(
+              (c) => c.arguments[0] === "xoxb-example",
+            ),
+          );
+          assert.ok(
+            mocks.core.setSecret.mock.calls.some(
+              (c) => c.arguments[0] === "https://example.com",
+            ),
           );
         } else {
           assert.fail(err);
@@ -86,7 +127,10 @@ describe("config", () => {
     });
 
     it("errors if the method is provided without a token", async () => {
-      mocks.core.getInput.withArgs("method").returns("chat.postMessage");
+      mocks.inputs = {
+        ...mocks.inputs,
+        method: "chat.postMessage",
+      };
       try {
         new Config(mocks.core);
         assert.fail("Failed to error when invalid inputs are provided");
@@ -121,7 +165,10 @@ describe("config", () => {
     });
 
     it("errors if a webhook is provided without the type", async () => {
-      mocks.core.getInput.withArgs("webhook").returns("https://example.com");
+      mocks.inputs = {
+        ...mocks.inputs,
+        webhook: "https://example.com",
+      };
       try {
         new Config(mocks.core);
         assert.fail("Failed to error when invalid inputs are provided");
@@ -139,8 +186,11 @@ describe("config", () => {
     });
 
     it("errors if the webhook type does not match techniques", async () => {
-      mocks.core.getInput.withArgs("webhook").returns("https://example.com");
-      mocks.core.getInput.withArgs("webhook-type").returns("post");
+      mocks.inputs = {
+        ...mocks.inputs,
+        webhook: "https://example.com",
+        "webhook-type": "post",
+      };
       try {
         new Config(mocks.core);
         assert.fail("Failed to error when invalid inputs are provided");
@@ -160,35 +210,50 @@ describe("config", () => {
 
   describe("mask", async () => {
     it("treats the provided token as a secret", async () => {
-      mocks.core.getInput.withArgs("token").returns("xoxb-example");
+      mocks.inputs = {
+        ...mocks.inputs,
+        token: "xoxb-example",
+      };
       try {
         await send(mocks.core);
         assert.fail("Failed to error for incomplete inputs while testing");
       } catch {
-        assert.ok(mocks.core.setSecret.withArgs("xoxb-example").called);
+        assert.ok(
+          mocks.core.setSecret.mock.calls.some(
+            (c) => c.arguments[0] === "xoxb-example",
+          ),
+        );
       }
     });
 
     it("treats the provided webhook as a secret", async () => {
-      mocks.core.getInput.withArgs("webhook").returns("https://slack.com");
-      mocks.core.getInput.withArgs("webhook-type").returns("incoming-webhook");
+      mocks.inputs = {
+        ...mocks.inputs,
+        webhook: "https://slack.com",
+        "webhook-type": "incoming-webhook",
+      };
       try {
         await send(mocks.core);
         assert.fail("Failed to error for incomplete inputs while testing");
       } catch {
-        assert.ok(mocks.core.setSecret.withArgs("https://slack.com").called);
+        assert.ok(
+          mocks.core.setSecret.mock.calls.some(
+            (c) => c.arguments[0] === "https://slack.com",
+          ),
+        );
       }
     });
   });
 
   describe("validate", () => {
     it('allow the "retries" option with lowercased space', async () => {
-      mocks.axios.post.returns(Promise.resolve("LGTM"));
-      mocks.core.getInput.withArgs("retries").returns(" rapid ");
-      mocks.core.getInput
-        .withArgs("webhook")
-        .returns("https://hooks.slack.com");
-      mocks.core.getInput.withArgs("webhook-type").returns("incoming-webhook");
+      mocks.axios.post._promise = Promise.resolve("LGTM");
+      mocks.inputs = {
+        ...mocks.inputs,
+        retries: " rapid ",
+        webhook: "https://hooks.slack.com",
+        "webhook-type": "incoming-webhook",
+      };
       try {
         await send(mocks.core);
       } catch (err) {
@@ -205,12 +270,13 @@ describe("config", () => {
     });
 
     it("errors if an invalid retries option is provided", async () => {
-      mocks.axios.post.returns(Promise.resolve("LGTM"));
-      mocks.core.getInput.withArgs("retries").returns("FOREVER");
-      mocks.core.getInput
-        .withArgs("webhook")
-        .returns("https://hooks.slack.com");
-      mocks.core.getInput.withArgs("webhook-type").returns("incoming-webhook");
+      mocks.axios.post._promise = Promise.resolve("LGTM");
+      mocks.inputs = {
+        ...mocks.inputs,
+        retries: "FOREVER",
+        webhook: "https://hooks.slack.com",
+        "webhook-type": "incoming-webhook",
+      };
       try {
         await send(mocks.core);
       } catch (err) {

--- a/test/fixtures/payload-invalid.json
+++ b/test/fixtures/payload-invalid.json
@@ -1,0 +1,2 @@
+{
+  "message": "a truncated file without an end

--- a/test/fixtures/payload-invalid.yaml
+++ b/test/fixtures/payload-invalid.yaml
@@ -1,0 +1,1 @@
+- "message": "assigned": "values"

--- a/test/fixtures/payload-with-env-vars.json
+++ b/test/fixtures/payload-with-env-vars.json
@@ -1,0 +1,56 @@
+{
+  "channel": "C0123456789",
+  "reply_broadcast": false,
+  "message": "Served ${{ env.NUMBER }} items",
+  "blocks": [
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "Served ${{ env.NUMBER }} items on: ${{ env.DETAILS }}"
+      }
+    },
+    {
+      "type": "divider"
+    },
+    {
+      "type": "section",
+      "block_id": "selector",
+      "text": {
+        "type": "mrkdwn",
+        "text": "Send feedback"
+      },
+      "accessory": {
+        "action_id": "response",
+        "type": "multi_static_select",
+        "placeholder": {
+          "type": "plain_text",
+          "text": "Select URL"
+        },
+        "options": [
+          {
+            "text": {
+              "type": "plain_text",
+              "text": "${{ github.apiUrl }}"
+            },
+            "value": "api"
+          },
+          {
+            "text": {
+              "type": "plain_text",
+              "text": "${{ github.serverUrl }}"
+            },
+            "value": "server"
+          },
+          {
+            "text": {
+              "type": "plain_text",
+              "text": "${{ github.graphqlUrl }}"
+            },
+            "value": "graphql"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/fixtures/payload-with-github-vars.json
+++ b/test/fixtures/payload-with-github-vars.json
@@ -1,0 +1,4 @@
+{
+  "message": "this matches an existing variable: ${{ github.apiUrl }}",
+  "channel": "C0123456789"
+}

--- a/test/fixtures/payload-with-missing-var.json
+++ b/test/fixtures/payload-with-missing-var.json
@@ -1,0 +1,3 @@
+{
+  "message": "What makes ${{ env.TREASURE }} a secret"
+}

--- a/test/fixtures/payload.json
+++ b/test/fixtures/payload.json
@@ -1,0 +1,4 @@
+{
+  "message": "drink water",
+  "channel": "C6H12O6H2O2"
+}

--- a/test/fixtures/payload.yaml
+++ b/test/fixtures/payload.yaml
@@ -1,0 +1,2 @@
+message: "drink water"
+channel: "C6H12O6H2O2"

--- a/test/fixtures/payload.yaml.md
+++ b/test/fixtures/payload.yaml.md
@@ -1,0 +1,2 @@
+# This file has an unknown extension
+message: "test"

--- a/test/fixtures/payload.yml
+++ b/test/fixtures/payload.yml
@@ -1,0 +1,2 @@
+message: "drink coffee"
+channel: "C0FFEEEEEEEE"

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -89,29 +89,25 @@ export class Mock {
    * Testing interface that removes internal state from existing mocks.
    */
   reset() {
-    // Clear lookup tables
-    this.inputs = {};
-    this.booleanInputs = {};
-
-    // Reset axios mock
+    this._isDebug = false;
     this.axios.post.mock.resetCalls();
     this.axios.post._promise = undefined;
-
-    // Reset apiCall mock
+    this.booleanInputs = {};
     this.calls.mock.resetCalls();
     this.calls._resolvesWith = undefined;
     this.calls._rejectsWith = undefined;
-
-    // Reset core mocks
-    for (const fn of Object.values(this.core)) {
-      fn.mock?.resetCalls();
-    }
-    this._isDebug = false;
-
-    // Reset webapi
+    this.core.debug.mock.resetCalls();
+    this.core.error.mock.resetCalls();
+    this.core.getBooleanInput.mock.resetCalls();
+    this.core.getInput.mock.resetCalls();
+    this.core.info.mock.resetCalls();
+    this.core.isDebug.mock.resetCalls();
+    this.core.setFailed.mock.resetCalls();
+    this.core.setOutput.mock.resetCalls();
+    this.core.setSecret.mock.resetCalls();
+    this.core.warning.mock.resetCalls();
+    this.inputs = {};
     this.webapi = {};
-
-    // Clear environment variables
     process.env.SLACK_TOKEN = "";
     process.env.SLACK_WEBHOOK_URL = "";
   }

--- a/test/logger.spec.js
+++ b/test/logger.spec.js
@@ -11,7 +11,7 @@ describe("logger", () => {
 
   describe("level", () => {
     it("debug", () => {
-      mocks.core.isDebug.returns(true);
+      mocks._isDebug = true;
       const { logger } = new Logger(mocks.core);
       const actual = logger.getLevel();
       const expected = LogLevel.DEBUG;
@@ -19,7 +19,7 @@ describe("logger", () => {
     });
 
     it("info", () => {
-      mocks.core.isDebug.returns(false);
+      mocks._isDebug = false;
       const { logger } = new Logger(mocks.core);
       const actual = logger.getLevel();
       const expected = LogLevel.INFO;

--- a/test/send.spec.js
+++ b/test/send.spec.js
@@ -19,62 +19,68 @@ describe("send", () => {
 
   describe("techniques", async () => {
     it("webhook trigger", async () => {
-      mocks.core.getInput
-        .withArgs("webhook")
-        .returns("https://hooks.slack.com");
-      mocks.core.getInput.withArgs("webhook-type").returns("webhook-trigger");
-      mocks.core.getInput.withArgs("payload").returns('"greetings": "hello"');
-      mocks.axios.post.returns(
-        Promise.resolve({ status: 200, data: { ok: true } }),
-      );
+      mocks.inputs = {
+        ...mocks.inputs,
+        webhook: "https://hooks.slack.com",
+        "webhook-type": "webhook-trigger",
+        payload: '"greetings": "hello"',
+      };
+      mocks.axios.post._promise = Promise.resolve({
+        status: 200,
+        data: { ok: true },
+      });
       await send(mocks.core);
-      assert.equal(mocks.core.setOutput.getCall(0).firstArg, "ok");
-      assert.equal(mocks.core.setOutput.getCall(0).lastArg, true);
-      assert.equal(mocks.core.setOutput.getCall(1).firstArg, "response");
+      assert.equal(mocks.core.setOutput.mock.calls[0].arguments[0], "ok");
+      assert.equal(mocks.core.setOutput.mock.calls[0].arguments[1], true);
+      assert.equal(mocks.core.setOutput.mock.calls[1].arguments[0], "response");
       assert.equal(
-        mocks.core.setOutput.getCall(1).lastArg,
+        mocks.core.setOutput.mock.calls[1].arguments[1],
         JSON.stringify({ ok: true }),
       );
-      assert.equal(mocks.core.setOutput.getCall(2).firstArg, "time");
-      assert.ok(mocks.core.setOutput.getCall(2).lastArg >= 0);
+      assert.equal(mocks.core.setOutput.mock.calls[2].arguments[0], "time");
+      assert.ok(mocks.core.setOutput.mock.calls[2].arguments[1] >= 0);
     });
 
     it("token", async () => {
       process.env.SLACK_WEBHOOK_URL = "https://example.com"; // https://github.com/slackapi/slack-github-action/issues/373
-      mocks.calls.resolves({ ok: true });
-      mocks.core.getInput.withArgs("method").returns("chat.postMessage");
-      mocks.core.getInput.withArgs("token").returns("xoxb-example");
-      mocks.core.getInput.withArgs("payload").returns('"text": "hello"');
+      mocks.calls._resolvesWith = { ok: true };
+      mocks.inputs = {
+        ...mocks.inputs,
+        method: "chat.postMessage",
+        token: "xoxb-example",
+        payload: '"text": "hello"',
+      };
       await send(mocks.core);
-      assert.equal(mocks.core.setOutput.getCall(0).firstArg, "ok");
-      assert.equal(mocks.core.setOutput.getCall(0).lastArg, true);
-      assert.equal(mocks.core.setOutput.getCall(1).firstArg, "response");
+      assert.equal(mocks.core.setOutput.mock.calls[0].arguments[0], "ok");
+      assert.equal(mocks.core.setOutput.mock.calls[0].arguments[1], true);
+      assert.equal(mocks.core.setOutput.mock.calls[1].arguments[0], "response");
       assert.equal(
-        mocks.core.setOutput.getCall(1).lastArg,
+        mocks.core.setOutput.mock.calls[1].arguments[1],
         JSON.stringify({ ok: true }),
       );
-      assert.equal(mocks.core.setOutput.getCall(2).firstArg, "time");
-      assert.ok(mocks.core.setOutput.getCall(2).lastArg >= 0);
+      assert.equal(mocks.core.setOutput.mock.calls[2].arguments[0], "time");
+      assert.ok(mocks.core.setOutput.mock.calls[2].arguments[1] >= 0);
     });
 
     it("incoming webhook", async () => {
       process.env.SLACK_TOKEN = "xoxb-example"; // https://github.com/slackapi/slack-github-action/issues/373
-      mocks.core.getInput
-        .withArgs("webhook")
-        .returns("https://hooks.slack.com");
-      mocks.core.getInput.withArgs("webhook-type").returns("incoming-webhook");
-      mocks.core.getInput.withArgs("payload").returns('"text": "hello"');
-      mocks.axios.post.returns(Promise.resolve({ status: 200, data: "ok" }));
+      mocks.inputs = {
+        ...mocks.inputs,
+        webhook: "https://hooks.slack.com",
+        "webhook-type": "incoming-webhook",
+        payload: '"text": "hello"',
+      };
+      mocks.axios.post._promise = Promise.resolve({ status: 200, data: "ok" });
       await send(mocks.core);
-      assert.equal(mocks.core.setOutput.getCall(0).firstArg, "ok");
-      assert.equal(mocks.core.setOutput.getCall(0).lastArg, true);
-      assert.equal(mocks.core.setOutput.getCall(1).firstArg, "response");
+      assert.equal(mocks.core.setOutput.mock.calls[0].arguments[0], "ok");
+      assert.equal(mocks.core.setOutput.mock.calls[0].arguments[1], true);
+      assert.equal(mocks.core.setOutput.mock.calls[1].arguments[0], "response");
       assert.equal(
-        mocks.core.setOutput.getCall(1).lastArg,
+        mocks.core.setOutput.mock.calls[1].arguments[1],
         JSON.stringify("ok"),
       );
-      assert.equal(mocks.core.setOutput.getCall(2).firstArg, "time");
-      assert.ok(mocks.core.setOutput.getCall(2).lastArg >= 0);
+      assert.equal(mocks.core.setOutput.mock.calls[2].arguments[0], "time");
+      assert.ok(mocks.core.setOutput.mock.calls[2].arguments[1] >= 0);
     });
   });
 });


### PR DESCRIPTION
### Summary

This PR updates unit tests to use the `node:test` package [mocks](https://nodejs.org/docs/latest-v20.x/api/test.html#mocking) and removes the [`sinon`](https://github.com/sinonjs/sinon) and [`@types/sinon`](https://www.npmjs.com/package/@types/sinon) packages with so much appreciation 🎁 

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).