### PR TITLE
ci: run the health score check with unit test workflow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -247,11 +247,3 @@ jobs:
         run: test -n "$PAYLOAD_FILE_OUTPUT_TIME"
         env:
           PAYLOAD_FILE_OUTPUT_TIME: ${{ steps.payload_file.outputs.time }}
-
-      - name: "chore(health): check up on recent changes to the health score"
-        uses: slackapi/slack-health-score@d58a419f15cdaff97e9aa7f09f95772830ab66f7 # v0.1.1
-        with:
-          codecov_token: ${{ secrets.CODECOV_API_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          extension: js
-          include: src


### PR DESCRIPTION
### Summary

This PR runs the health score check with the unit test workflow which includes test coverage. We remove it from the integration tests to remove errors!

Follows https://github.com/slackapi/slack-github-action/pull/553

### Preview

Before: 
<img width="1241" height="479" alt="health" src="https://github.com/user-attachments/assets/896e3324-3849-4e73-a9cd-229e7476206a" />

### Requirements <!-- Place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
