### PR TITLE
Update action runtime from Node.js 20 to Node.js 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -54,5 +54,5 @@ outputs:
   ts:
     description: "The timestamp of a Slack message or event in the response."
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"


### PR DESCRIPTION
### Summary

Updates the GitHub Action runtime from `node20` to `node24` in `action.yml`.

GitHub has announced that Node.js 20 actions are deprecated and will be forced to run on Node.js 24 starting **June 2, 2026**. This change proactively updates the `runs.using` field from `node20` to `node24` to prepare for that transition.

Related: #487

### Requirements <!-- Place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).