### PR TITLE
fix: handle webhook errors without toJSON

### DIFF
--- a/src/webhook.js
+++ b/src/webhook.js
@@ -33,11 +33,20 @@ export default class Webhook {
       config.core.setOutput("response", JSON.stringify(response.data));
       config.core.debug(JSON.stringify(response.data));
     } catch (/** @type {any} */ err) {
-      const response = err.toJSON();
+      const response =
+        typeof err?.toJSON === "function"
+          ? err.toJSON()
+          : {
+              message: err?.message,
+              status: err?.response?.status,
+            };
+
       config.core.setOutput("ok", response.status === 200);
       config.core.setOutput("response", JSON.stringify(response.message));
-      config.core.debug(response);
-      throw new SlackError(config.core, response.message);
+      config.core.debug(JSON.stringify(response));
+      throw new SlackError(config.core, response.message ?? "Request failed", {
+        cause: err,
+      });
     }
   }
 

--- a/test/webhook.spec.js
+++ b/test/webhook.spec.js
@@ -160,6 +160,32 @@ describe("webhook", () => {
       assert.equal(mocks.core.setOutput.getCall(0).lastArg, false);
       assert.equal(mocks.core.setOutput.getCall(1).firstArg, "response");
     });
+
+    it("handles errors without toJSON", async () => {
+      mocks.core.getInput
+        .withArgs("webhook")
+        .returns("\"https://hooks.slack.com\"");
+      mocks.core.getInput.withArgs("webhook-type").returns("incoming-webhook");
+      mocks.core.getInput.withArgs("payload").returns("text: test");
+      mocks.core.getBooleanInput.withArgs("errors").returns(true);
+      mocks.axios.post.returns(Promise.reject(new TypeError("Invalid URL")));
+
+      try {
+        await send(mocks.core);
+        assert.fail("Failed to throw for non-axios error");
+      } catch (err) {
+        if (err instanceof SlackError) {
+          assert.ok(err.message.includes("Invalid URL"));
+        } else {
+          assert.fail(err);
+        }
+      }
+
+      assert.equal(mocks.core.setOutput.getCall(0).firstArg, "ok");
+      assert.equal(mocks.core.setOutput.getCall(0).lastArg, false);
+      assert.equal(mocks.core.setOutput.getCall(1).firstArg, "response");
+      assert.equal(mocks.core.setOutput.getCall(1).lastArg, '"Invalid URL"');
+    });
   });
 
   describe("proxies", () => {


### PR DESCRIPTION
Fixes #511

Webhook.post currently assumes every thrown error implements toJSON(). That crashes error handling itself for non-Axios errors (for example invalid webhook input), hiding the original cause.

This change adds a safe fallback when toJSON is not available, preserves status/message outputs, and throws SlackError with a cause so the root error is still available.

Also adds a regression test for a non-Axios TypeError path.

Greetings, saschabuehrle