### PR TITLE
chore: add 7-day Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: "monthly"
     cooldown:
       default-days: 7
+      exclude:
+        - "@slack/*"
     ignore:
       - dependency-name: "@types/node"
         versions:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     ignore:
       - dependency-name: "@types/node"
         versions:
@@ -12,3 +14,5 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Adds a 7-day Dependabot cooldown to the npm and github-actions update blocks in `.github/dependabot.yml`, while excluding `@slack/*` packages from the npm cooldown so Slack-owned packages can still update immediately.

This is partly motivated by prior workflow hardening / analysis work around `zizmor` in this repo and related health-score-driven PRs:
- `zizmor` docs: https://docs.zizmor.sh/
- `zizmor` repo: https://github.com/zizmorcore/zizmor
- prior repo PR: #441
- health score / secure practices PR: #484

The goal here is to slow down most ecosystem updates a bit, without getting in the way of first-party `@slack/*` package updates or adjacent workflow security work.