### PR TITLE
feat: add instrumentation to address error rates

### DIFF
--- a/.changeset/sharp-pens-accept.md
+++ b/.changeset/sharp-pens-accept.md
@@ -1,0 +1,5 @@
+---
+"@slack/slack-github-action": patch
+---
+
+feat: add instrumentation to address error rates

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "slack-github-action",
+  "name": "@slack/slack-github-action",
   "version": "3.0.2",
   "private": true,
   "description": "The official Slack GitHub Action. Use this to send data into your Slack workspace",

--- a/src/config.js
+++ b/src/config.js
@@ -1,10 +1,10 @@
 import os from "node:os";
 import webapi from "@slack/web-api";
 import axios from "axios";
+import packageJson from "../package.json" with { type: "json" };
 import Content from "./content.js";
 import SlackError from "./errors.js";
 import Logger from "./logger.js";
-import packageJson from "../package.json" with { type: "json" };
 
 /**
  * Options and settings set as inputs to this action.

--- a/src/config.js
+++ b/src/config.js
@@ -1,3 +1,4 @@
+import os from "node:os";
 import webapi from "@slack/web-api";
 import axios from "axios";
 import Content from "./content.js";
@@ -137,7 +138,10 @@ export default class Config {
       version: packageJson.version,
     });
     this.axios.defaults.headers.common["User-Agent"] =
-      `${packageJson.name.replace("/", ":")}/${packageJson.version}`;
+      `${packageJson.name.replace("/", ":")}/${packageJson.version} ` +
+      `axios/${this.axios.VERSION} ` +
+      `node/${process.version.replace("v", "")} ` +
+      `${os.platform()}/${os.release()}`;
   }
 
   /**

--- a/src/config.js
+++ b/src/config.js
@@ -136,6 +136,8 @@ export default class Config {
       name: packageJson.name,
       version: packageJson.version,
     });
+    this.axios.defaults.headers.common["User-Agent"] =
+      `${packageJson.name.replace("/", ":")}/${packageJson.version}`;
   }
 
   /**

--- a/src/config.js
+++ b/src/config.js
@@ -3,6 +3,7 @@ import axios from "axios";
 import Content from "./content.js";
 import SlackError from "./errors.js";
 import Logger from "./logger.js";
+import packageJson from "../package.json" with { type: "json" };
 
 /**
  * Options and settings set as inputs to this action.
@@ -119,11 +120,22 @@ export default class Config {
         core.getInput("webhook") || process.env.SLACK_WEBHOOK_URL || null,
       webhookType: core.getInput("webhook-type"),
     };
+    this.instrument();
     this.mask();
     this.validate(core);
     core.debug(`Gathered action inputs: ${JSON.stringify(this.inputs)}`);
     this.content = new Content().get(this);
     core.debug(`Parsed request content: ${JSON.stringify(this.content)}`);
+  }
+
+  /**
+   * Add user agent metadata for instrumentation.
+   */
+  instrument() {
+    this.webapi.addAppMetadata({
+      name: packageJson.name,
+      version: packageJson.version,
+    });
   }
 
   /**

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -1,5 +1,7 @@
 import assert from "node:assert";
 import { beforeEach, describe, it } from "node:test";
+import webapi from "@slack/web-api";
+import sinon from "sinon";
 import Config from "../src/config.js";
 import SlackError from "../src/errors.js";
 import send from "../src/send.js";
@@ -154,6 +156,28 @@ describe("config", () => {
         } else {
           assert.fail(err);
         }
+      }
+    });
+  });
+
+  describe("instrument", () => {
+    it("adds metadata to webapi with package name and version", async () => {
+      const stub = sinon.stub();
+      const original = Object.getOwnPropertyDescriptor(webapi, "addAppMetadata");
+      Object.defineProperty(webapi, "addAppMetadata", {
+        value: stub,
+        configurable: true,
+      });
+      try {
+        mocks.core.getInput.withArgs("method").returns("chat.postMessage");
+        mocks.core.getInput.withArgs("token").returns("xoxb-example");
+        new Config(mocks.core);
+        assert.ok(stub.calledOnce);
+        const { name, version } = stub.firstCall.args[0];
+        assert.equal(name, "@slack/slack-github-action");
+        assert.ok(version);
+      } finally {
+        Object.defineProperty(webapi, "addAppMetadata", original);
       }
     });
   });

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -163,7 +163,10 @@ describe("config", () => {
   describe("instrument", () => {
     it("adds metadata to webapi with package name and version", async () => {
       const stub = sinon.stub();
-      const original = Object.getOwnPropertyDescriptor(webapi, "addAppMetadata");
+      const original = Object.getOwnPropertyDescriptor(
+        webapi,
+        "addAppMetadata",
+      );
       Object.defineProperty(webapi, "addAppMetadata", {
         value: stub,
         configurable: true,

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -180,6 +180,21 @@ describe("config", () => {
         Object.defineProperty(webapi, "addAppMetadata", original);
       }
     });
+
+    it("adds metadata to webhook with package name and version", async () => {
+      mocks.core.getInput.withArgs("method").returns("chat.postMessage");
+      mocks.core.getInput.withArgs("token").returns("xoxb-example");
+      const config = new Config(mocks.core);
+      assert.ok(
+        config.axios.defaults.headers.common["User-Agent"].startsWith(
+          "@slack:slack-github-action/",
+        ),
+      );
+      assert.ok(
+        config.axios.defaults.headers.common["User-Agent"].length >
+          "@slack:slack-github-action/".length,
+      );
+    });
   });
 
   describe("mask", async () => {


### PR DESCRIPTION
### Summary

This PR adds instrumentation to address error rates with a `User-Agent` header added to requests 🎹 

### Preview

With additional logging in development to reveal we find these headers for different techniques:

#### API Method

```
@slack:slack-github-action/3.0.2 @slack:web-api/7.15.0 node/24.15.0 linux/6.12.76-linuxkit
```

#### Webhook

```
@slack:slack-github-action/3.0.2 axios/1.15.0 node/24.15.0 linux/6.12.76-linuxkit
```

#### CLI

🎺 Instrumentation is left to adjacent implementations for installations and particular command usage.

### Requirements <!-- Place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
