### PR TITLE
docs: note requirement of checkout to upload existing files

### DIFF
--- a/docs/sending-data-slack-api-method.md
+++ b/docs/sending-data-slack-api-method.md
@@ -123,6 +123,8 @@ Posting [threaded replies to a message](/messaging/#threading) from a past job c
 Calling [a Slack API method](/reference/methods) with [`@slack/web-api`](/tools/node-slack-sdk/web-api/) makes [uploading a file](/messaging/working-with-files#uploading_files) just another API call with all of the convenience of the [`files.uploadV2`](/tools/node-slack-sdk/web-api/#upload-a-file) method:
 
 ```yaml
+- name: Checkout an imagined project
+  uses: actions/checkout@v6
 - name: Share a file to that channel
   uses: slackapi/slack-github-action@v3.0.3
   with:
@@ -134,6 +136,8 @@ Calling [a Slack API method](/reference/methods) with [`@slack/web-api`](/tools/
       file: "./path/to/results.out"
       filename: "results-${{ github.sha }}.out"
 ```
+
+The [checkout](https://github.com/actions/checkout) step makes existing contents available to upload from a workflow.
 
 ## Expected outputs
 
@@ -172,7 +176,6 @@ https://github.com/slackapi/slack-github-action/blob/main/example-workflows/Tech
 <summary><strong>Invite a usergroup to channel</strong></summary>
 
 This workflow creates a channel after a bug is reported and add members of a usergroup by chaining multiple Slack API method calls together.
-
 
 ```js reference
 https://github.com/slackapi/slack-github-action/blob/main/example-workflows/Technique_2_Slack_API_Method/invite.yml

--- a/docs/sending-data-slack-api-method.md
+++ b/docs/sending-data-slack-api-method.md
@@ -137,7 +137,7 @@ Calling [a Slack API method](/reference/methods) with [`@slack/web-api`](/tools/
       filename: "results-${{ github.sha }}.out"
 ```
 
-The [checkout](https://github.com/actions/checkout) step makes existing contents available to upload from a workflow.
+The [checkout](https://github.com/actions/checkout) step makes existing content available to upload from a workflow.
 
 ## Expected outputs
 


### PR DESCRIPTION
### Summary

This PR adds a note that the `actions/checkout` step is required to upload existing contents as a file with the API method technique 📚 

From discussion of #448 workarounds!

### Requirements <!-- Place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
