### PR TITLE
chore: open changeset release pull requests as draft

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
           commit: "chore: release"
+          prDraft: create
           title: "chore: release"
           version: npm run version
         env:


### PR DESCRIPTION
### Summary

Open changeset release PRs as drafts using the `prDraft: create` option from changesets/action. This prevents version PRs from being accidentally merged before they're reviewed.

Reference: https://github.com/changesets/action/blob/main/CHANGELOG.md#180

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).