### PR TITLE
chore: block @dependabot updates to @types/node@26

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
       - dependency-name: "@types/node"
         versions:
           - "25.x"
+          - "26.x"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
### Summary

This pull request guards the Slack GitHub Action against Dependabot bumping `@types/node` to v26.

- Adds `"26.x"` alongside the existing `"25.x"` entry in the `@types/node` ignore list in `.github/dependabot.yml`.

### Notes

We hope to match runner support `node` version for now:

https://github.com/slackapi/slack-github-action/blob/977625e666598c49fd5bc6a67dcaa35bff6f4f5e/.nvmrc#L1

### Requirements <!-- Place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
