### PR TITLE
refactor: send webhooks with the @slack/webhook package

### DIFF
--- a/.changeset/webhook-trigger-sdk.md
+++ b/.changeset/webhook-trigger-sdk.md
@@ -1,0 +1,5 @@
+---
+"@slack/slack-github-action": patch
+---
+
+Send `webhook-trigger` payloads through the [`@slack/webhook`](https://docs.slack.dev/tools/node-slack-sdk/webhook) package instead of a bespoke request, sharing its retry policies and returning the complete trigger response.

--- a/.changeset/webhook-trigger-sdk.md
+++ b/.changeset/webhook-trigger-sdk.md
@@ -2,4 +2,4 @@
 "@slack/slack-github-action": patch
 ---
 
-Send `webhook-trigger` payloads through the [`@slack/webhook`](https://docs.slack.dev/tools/node-slack-sdk/webhook) package instead of a bespoke request, sharing its retry policies and returning the complete trigger response.
+refactor: send webhooks with the [`@slack/webhook`](https://docs.slack.dev/tools/node-slack-sdk/webhook) package

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@actions/github": "^9.1.1",
         "@slack/logger": "^4.0.1",
         "@slack/web-api": "^7.16.0",
-        "@slack/webhook": "7.2.0-rc.1",
+        "@slack/webhook": "7.2.0-rc.2",
         "flat": "^6.0.1",
         "https-proxy-agent": "^9.0.0",
         "js-yaml": "^4.2.0",
@@ -884,16 +884,16 @@
       }
     },
     "node_modules/@slack/webhook": {
-      "version": "7.2.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@slack/webhook/-/webhook-7.2.0-rc.1.tgz",
-      "integrity": "sha512-ZMqxzG1QVHOKHj46WztoWDPuZXWHwFFoW7Tvkl8RvgOv+Gyhjw7kKiJ4AxpIIungz8XIHomBqm1Z4kShwn13/w==",
+      "version": "7.2.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@slack/webhook/-/webhook-7.2.0-rc.2.tgz",
+      "integrity": "sha512-4O0LKiIFJdHBqOPb6lkO9SxqRN9RVIWXMI9QBPzfZrDiLC3pJACQNCETauLPbMonGtJYrt8B/xOOEQA+GCuWfQ==",
       "license": "MIT",
       "dependencies": {
         "@slack/types": "^2.20.1",
         "@types/node": ">=18",
         "@types/retry": "0.12.0",
         "axios": "^1.16.0",
-        "p-retry": "^4",
+        "p-retry": "^4.6.2",
         "retry": "^0.13.1"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@actions/github": "^9.1.1",
         "@slack/logger": "^4.0.1",
         "@slack/web-api": "^7.16.0",
-        "@slack/webhook": "file:../node-slack-sdk/packages/webhook",
+        "@slack/webhook": "7.2.0-rc.1",
         "flat": "^6.0.1",
         "https-proxy-agent": "^9.0.0",
         "js-yaml": "^4.2.0",
@@ -35,26 +35,6 @@
       "engines": {
         "node": ">=24.11.0",
         "npm": ">=11.6.1"
-      }
-    },
-    "../node-slack-sdk/packages/webhook": {
-      "name": "@slack/webhook",
-      "version": "7.0.9",
-      "license": "MIT",
-      "dependencies": {
-        "@slack/types": "^2.20.1",
-        "@types/node": ">=18",
-        "@types/retry": "0.12.0",
-        "axios": "^1.16.0",
-        "p-retry": "^4",
-        "retry": "^0.13.1"
-      },
-      "devDependencies": {
-        "nock": "^14.0.6"
-      },
-      "engines": {
-        "node": ">= 18",
-        "npm": ">= 8.6.0"
       }
     },
     "node_modules/@actions/core": {
@@ -893,8 +873,35 @@
       }
     },
     "node_modules/@slack/webhook": {
-      "resolved": "../node-slack-sdk/packages/webhook",
-      "link": true
+      "version": "7.2.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@slack/webhook/-/webhook-7.2.0-rc.1.tgz",
+      "integrity": "sha512-ZMqxzG1QVHOKHj46WztoWDPuZXWHwFFoW7Tvkl8RvgOv+Gyhjw7kKiJ4AxpIIungz8XIHomBqm1Z4kShwn13/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@slack/types": "^2.20.1",
+        "@types/node": ">=18",
+        "@types/retry": "0.12.0",
+        "axios": "^1.16.0",
+        "p-retry": "^4",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
+    },
+    "node_modules/@slack/webhook/node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/@types/flat": {
       "version": "5.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,10 @@
       "dependencies": {
         "@slack/types": "^2.20.1",
         "@types/node": ">=18",
-        "axios": "^1.16.0"
+        "@types/retry": "0.12.0",
+        "axios": "^1.16.0",
+        "p-retry": "^4",
+        "retry": "^0.13.1"
       },
       "devDependencies": {
         "nock": "^14.0.6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@actions/github": "^9.1.1",
         "@slack/logger": "^4.0.1",
         "@slack/web-api": "^7.16.0",
-        "@slack/webhook": "7.2.0",
+        "@slack/webhook": "^7.2.0",
         "flat": "^6.0.1",
         "https-proxy-agent": "^9.0.0",
         "js-yaml": "^5.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,7 @@
         "flat": "^6.0.1",
         "https-proxy-agent": "^9.0.0",
         "js-yaml": "^4.2.0",
-        "markup-js": "^1.5.21",
-        "p-retry": "^8.0.0"
+        "markup-js": "^1.5.21"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.5.1",
@@ -1634,18 +1633,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-network-error": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.2.tgz",
-      "integrity": "sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -1914,21 +1901,6 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
-    },
-    "node_modules/p-retry": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-8.0.0.tgz",
-      "integrity": "sha512-kFVqH1HxOHp8LupNsOys7bSV09VYTRLxarH/mokO4Rqhk6wGi70E0jh4VzvVGXfEVNggHoHLAMWsQqHyU1Ey9A==",
-      "license": "MIT",
-      "dependencies": {
-        "is-network-error": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/p-timeout": {
       "version": "3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@actions/github": "^9.1.1",
         "@slack/logger": "^4.0.1",
         "@slack/web-api": "^7.16.0",
-        "@slack/webhook": "7.2.0-rc.2",
+        "@slack/webhook": "7.2.0-rc.3",
         "flat": "^6.0.1",
         "https-proxy-agent": "^9.0.0",
         "js-yaml": "^4.2.0",
@@ -884,9 +884,9 @@
       }
     },
     "node_modules/@slack/webhook": {
-      "version": "7.2.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@slack/webhook/-/webhook-7.2.0-rc.2.tgz",
-      "integrity": "sha512-4O0LKiIFJdHBqOPb6lkO9SxqRN9RVIWXMI9QBPzfZrDiLC3pJACQNCETauLPbMonGtJYrt8B/xOOEQA+GCuWfQ==",
+      "version": "7.2.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@slack/webhook/-/webhook-7.2.0-rc.3.tgz",
+      "integrity": "sha512-lBNEJpxWXJ0IPEZOFmt/7eypkmtVl+r1D6ZOZnaa8tQi1OfUx9OvR/FXnUHvwiF11RFblqchEvjwSy147ALwWw==",
       "license": "MIT",
       "dependencies": {
         "@slack/types": "^2.20.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@actions/github": "^9.1.1",
         "@slack/logger": "^4.0.1",
         "@slack/web-api": "^7.16.0",
-        "@slack/webhook": "7.2.0-rc.3",
+        "@slack/webhook": "7.2.0",
         "flat": "^6.0.1",
         "https-proxy-agent": "^9.0.0",
         "js-yaml": "^4.2.0",
@@ -884,9 +884,9 @@
       }
     },
     "node_modules/@slack/webhook": {
-      "version": "7.2.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@slack/webhook/-/webhook-7.2.0-rc.3.tgz",
-      "integrity": "sha512-lBNEJpxWXJ0IPEZOFmt/7eypkmtVl+r1D6ZOZnaa8tQi1OfUx9OvR/FXnUHvwiF11RFblqchEvjwSy147ALwWw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@slack/webhook/-/webhook-7.2.0.tgz",
+      "integrity": "sha512-iGL0S6NI9Bv/kg3FS0J5EaLF1kd7uw5pdrfndqz+h1yhgguiVpRL7ReJg9Cia5knS9hUSCRY5MTjeroBwxdKtw==",
       "license": "MIT",
       "dependencies": {
         "@slack/types": "^2.20.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,12 @@
         "@actions/github": "^9.1.1",
         "@slack/logger": "^4.0.1",
         "@slack/web-api": "^7.16.0",
-        "axios": "^1.16.0",
-        "axios-retry": "^4.5.0",
+        "@slack/webhook": "file:../node-slack-sdk/packages/webhook",
         "flat": "^6.0.1",
         "https-proxy-agent": "^9.0.0",
         "js-yaml": "^4.2.0",
-        "markup-js": "^1.5.21"
+        "markup-js": "^1.5.21",
+        "p-retry": "^8.0.0"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.16",
@@ -35,6 +35,23 @@
       "engines": {
         "node": ">=24.11.0",
         "npm": ">=11.6.1"
+      }
+    },
+    "../node-slack-sdk/packages/webhook": {
+      "name": "@slack/webhook",
+      "version": "7.0.9",
+      "license": "MIT",
+      "dependencies": {
+        "@slack/types": "^2.20.1",
+        "@types/node": ">=18",
+        "axios": "^1.16.0"
+      },
+      "devDependencies": {
+        "nock": "^14.0.6"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
       }
     },
     "node_modules/@actions/core": {
@@ -859,6 +876,23 @@
         "npm": ">= 8.6.0"
       }
     },
+    "node_modules/@slack/web-api/node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@slack/webhook": {
+      "resolved": "../node-slack-sdk/packages/webhook",
+      "link": true
+    },
     "node_modules/@types/flat": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/@types/flat/-/flat-5.0.5.tgz",
@@ -981,18 +1015,6 @@
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
-      }
-    },
-    "node_modules/axios-retry": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.5.0.tgz",
-      "integrity": "sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "is-retry-allowed": "^2.2.0"
-      },
-      "peerDependencies": {
-        "axios": "0.x || 1.x"
       }
     },
     "node_modules/before-after-hook": {
@@ -1590,6 +1612,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-network-error": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.2.tgz",
+      "integrity": "sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -1598,18 +1632,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
-      }
-    },
-    "node_modules/is-retry-allowed": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
-      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-stream": {
@@ -1872,16 +1894,18 @@
       "license": "MIT"
     },
     "node_modules/p-retry": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-8.0.0.tgz",
+      "integrity": "sha512-kFVqH1HxOHp8LupNsOys7bSV09VYTRLxarH/mokO4Rqhk6wGi70E0jh4VzvVGXfEVNggHoHLAMWsQqHyU1Ey9A==",
       "license": "MIT",
       "dependencies": {
-        "@types/retry": "0.12.0",
-        "retry": "^0.13.1"
+        "is-network-error": "^1.3.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-timeout": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@actions/github": "^9.1.1",
     "@slack/logger": "^4.0.1",
     "@slack/web-api": "^7.16.0",
-    "@slack/webhook": "7.2.0-rc.2",
+    "@slack/webhook": "7.2.0-rc.3",
     "flat": "^6.0.1",
     "https-proxy-agent": "^9.0.0",
     "js-yaml": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@actions/github": "^9.1.1",
     "@slack/logger": "^4.0.1",
     "@slack/web-api": "^7.16.0",
-    "@slack/webhook": "7.2.0-rc.1",
+    "@slack/webhook": "7.2.0-rc.2",
     "flat": "^6.0.1",
     "https-proxy-agent": "^9.0.0",
     "js-yaml": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -50,8 +50,7 @@
     "flat": "^6.0.1",
     "https-proxy-agent": "^9.0.0",
     "js-yaml": "^4.2.0",
-    "markup-js": "^1.5.21",
-    "p-retry": "^8.0.0"
+    "markup-js": "^1.5.21"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -46,12 +46,12 @@
     "@actions/github": "^9.1.1",
     "@slack/logger": "^4.0.1",
     "@slack/web-api": "^7.16.0",
-    "axios": "^1.16.0",
-    "axios-retry": "^4.5.0",
+    "@slack/webhook": "file:../node-slack-sdk/packages/webhook",
     "flat": "^6.0.1",
     "https-proxy-agent": "^9.0.0",
     "js-yaml": "^4.2.0",
-    "markup-js": "^1.5.21"
+    "markup-js": "^1.5.21",
+    "p-retry": "^8.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.16",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@actions/github": "^9.1.1",
     "@slack/logger": "^4.0.1",
     "@slack/web-api": "^7.16.0",
-    "@slack/webhook": "7.2.0-rc.3",
+    "@slack/webhook": "7.2.0",
     "flat": "^6.0.1",
     "https-proxy-agent": "^9.0.0",
     "js-yaml": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@actions/github": "^9.1.1",
     "@slack/logger": "^4.0.1",
     "@slack/web-api": "^7.16.0",
-    "@slack/webhook": "7.2.0",
+    "@slack/webhook": "^7.2.0",
     "flat": "^6.0.1",
     "https-proxy-agent": "^9.0.0",
     "js-yaml": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@actions/github": "^9.1.1",
     "@slack/logger": "^4.0.1",
     "@slack/web-api": "^7.16.0",
-    "@slack/webhook": "file:../node-slack-sdk/packages/webhook",
+    "@slack/webhook": "7.2.0-rc.1",
     "flat": "^6.0.1",
     "https-proxy-agent": "^9.0.0",
     "js-yaml": "^4.2.0",

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,5 @@
 import webapi from "@slack/web-api";
+import webhook from "@slack/webhook";
 import packageJson from "../package.json" with { type: "json" };
 import Content from "./content.js";
 import SlackError from "./errors.js";
@@ -81,6 +82,11 @@ export default class Config {
   webapi;
 
   /**
+   * @type {import("@slack/webhook")} - Slack webhook client.
+   */
+  webhook;
+
+  /**
    * Gather values from the job inputs and use defaults or error for the missing
    * ones.
    *
@@ -94,6 +100,7 @@ export default class Config {
     this.core = core;
     this.logger = new Logger(core).logger;
     this.webapi = webapi;
+    this.webhook = webhook;
     this.inputs = {
       api: core.getInput("api"),
       errors: core.getBooleanInput("errors"),
@@ -123,12 +130,13 @@ export default class Config {
 
   /**
    * Add user agent metadata for instrumentation.
-   *
-   * The @slack/webhook and @slack/web-api SDKs set their own User-Agent
-   * headers, so the action only registers app metadata with web-api here.
    */
   instrument() {
     this.webapi.addAppMetadata({
+      name: packageJson.name,
+      version: packageJson.version,
+    });
+    this.webhook.addAppMetadata({
       name: packageJson.name,
       version: packageJson.version,
     });

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,4 @@
-import os from "node:os";
 import webapi from "@slack/web-api";
-import axios from "axios";
 import packageJson from "../package.json" with { type: "json" };
 import Content from "./content.js";
 import SlackError from "./errors.js";
@@ -61,11 +59,6 @@ export default class Config {
   inputs;
 
   /**
-   * @type {import("axios").AxiosStatic} - The axios client.
-   */
-  axios;
-
-  /**
    * @type {Content} - The parsed payload data to send.
    */
   content;
@@ -98,7 +91,6 @@ export default class Config {
    * @param {import("@actions/core")} core - GitHub Actions core utilities.
    */
   constructor(core) {
-    this.axios = axios;
     this.core = core;
     this.logger = new Logger(core).logger;
     this.webapi = webapi;
@@ -131,17 +123,15 @@ export default class Config {
 
   /**
    * Add user agent metadata for instrumentation.
+   *
+   * The @slack/webhook and @slack/web-api SDKs set their own User-Agent
+   * headers, so the action only registers app metadata with web-api here.
    */
   instrument() {
     this.webapi.addAppMetadata({
       name: packageJson.name,
       version: packageJson.version,
     });
-    this.axios.defaults.headers.common["User-Agent"] =
-      `${packageJson.name.replace("/", ":")}/${packageJson.version} ` +
-      `axios/${this.axios.VERSION} ` +
-      `node/${process.version.replace("v", "")} ` +
-      `${os.platform()}/${os.release()}`;
   }
 
   /**

--- a/src/webhook.js
+++ b/src/webhook.js
@@ -101,9 +101,18 @@ export default class Webhook {
       if (!proxy) {
         return undefined;
       }
-      return {
-        httpsAgent: new HttpsProxyAgent(proxy),
-      };
+      switch (new URL(proxy).protocol) {
+        case "https:":
+        case "http:":
+          return {
+            httpsAgent: new HttpsProxyAgent(proxy),
+          };
+        default:
+          throw new SlackError(
+            config.core,
+            `Unsupported URL protocol: ${proxy}`,
+          );
+      }
     } catch (/** @type {any} */ err) {
       throw new SlackError(config.core, "Failed to configure the HTTPS proxy", {
         cause: err,

--- a/src/webhook.js
+++ b/src/webhook.js
@@ -26,7 +26,7 @@ export default class Webhook {
     }
     const url = config.inputs.webhook;
     const options = {
-      agent: this.proxies(config)?.httpsAgent,
+      agent: this.proxies(config),
       retryConfig: this.retries(config.inputs.retries),
     };
     try {
@@ -66,9 +66,9 @@ export default class Webhook {
   }
 
   /**
-   * Return configurations for https proxy options if these are set.
+   * Return an https proxy agent if a proxy is set.
    * @param {Config} config
-   * @returns {{ httpsAgent: HttpsProxyAgent<string> } | undefined}
+   * @returns {HttpsProxyAgent<string> | undefined}
    * @see {@link https://github.com/slackapi/slack-github-action/pull/132}
    * @see {@link https://github.com/slackapi/slack-github-action/pull/205}
    */
@@ -90,9 +90,7 @@ export default class Webhook {
       switch (new URL(proxy).protocol) {
         case "https:":
         case "http:":
-          return {
-            httpsAgent: new HttpsProxyAgent(proxy),
-          };
+          return new HttpsProxyAgent(proxy);
         default:
           throw new SlackError(
             config.core,

--- a/src/webhook.js
+++ b/src/webhook.js
@@ -1,11 +1,15 @@
-import axiosRetry, { exponentialDelay, linearDelay } from "axios-retry";
+import webapi from "@slack/web-api";
+import { ErrorCode, IncomingWebhook, WebhookTrigger } from "@slack/webhook";
 import { HttpsProxyAgent } from "https-proxy-agent";
+import pRetry, { AbortError } from "p-retry";
 import Config from "./config.js";
 import SlackError from "./errors.js";
 
 /**
- * This Webhook class posts the configured payload to the provided webhook, with
- * whatever additional settings set.
+ * The Webhook class posts the configured payload to the provided webhook using
+ * the @slack/webhook SDK, choosing the client by the configured webhook type.
+ *
+ * @see {@link https://docs.slack.dev/tools/node-slack-sdk/webhook/}
  */
 export default class Webhook {
   /**
@@ -15,69 +19,121 @@ export default class Webhook {
     if (!config.inputs.webhook) {
       throw new SlackError(config.core, "No webhook was provided to post to");
     }
-    /**
-     * @type {import("axios-retry").IAxiosRetryConfig}
-     * @see {@link https://www.npmjs.com/package/axios-retry}
-     */
-    const retries = this.retries(config.inputs.retries);
-    axiosRetry(config.axios, retries);
-    try {
-      const response = await config.axios.post(
-        config.inputs.webhook,
-        config.content.values,
-        {
-          ...this.proxies(config),
-        },
-      );
-      config.core.setOutput("ok", response.status === 200);
-      config.core.setOutput("response", JSON.stringify(response.data));
-      config.core.debug(JSON.stringify(response.data));
-    } catch (/** @type {any} */ err) {
-      const response = err.toJSON();
-      config.core.setOutput("ok", response.status === 200);
-      config.core.setOutput("response", JSON.stringify(response.message));
-      config.core.debug(response);
-      throw new SlackError(config.core, response.message);
+    switch (config.inputs.webhookType) {
+      case "incoming-webhook":
+        return await this.postIncomingWebhook(config);
+      case "webhook-trigger":
+        return await this.postWebhookTrigger(config);
+      default:
+        throw new SlackError(
+          config.core,
+          `Unknown webhook type: ${config.inputs.webhookType}`,
+        );
     }
   }
 
   /**
-   * Return configurations for http proxy options if these are set.
+   * Post using the @slack/webhook IncomingWebhook client.
    * @param {Config} config
-   * @returns {import("axios").AxiosRequestConfig | undefined}
-   * @see {@link https://github.com/slackapi/slack-github-action/pull/132}
+   */
+  async postIncomingWebhook(config) {
+    const webhook = new IncomingWebhook(
+      /** @type {string} */ (config.inputs.webhook),
+      { agent: this.proxies(config)?.httpsAgent },
+    );
+    try {
+      const response = await this.send(config, () =>
+        webhook.send(config.content.values),
+      );
+      config.core.setOutput("ok", true);
+      config.core.setOutput("response", JSON.stringify(response.text));
+      config.core.debug(JSON.stringify(response.text));
+    } catch (/** @type {any} */ err) {
+      config.core.setOutput("ok", false);
+      config.core.setOutput("response", JSON.stringify(err.message));
+      config.core.debug(err);
+      throw new SlackError(config.core, err.message);
+    }
+  }
+
+  /**
+   * Post using the @slack/webhook WebhookTrigger client.
+   * @param {Config} config
+   */
+  async postWebhookTrigger(config) {
+    const trigger = new WebhookTrigger(
+      /** @type {string} */ (config.inputs.webhook),
+      { agent: this.proxies(config)?.httpsAgent },
+    );
+    try {
+      const response = await this.send(config, () =>
+        trigger.send(config.content.values),
+      );
+      config.core.setOutput("ok", response.ok);
+      config.core.setOutput("response", JSON.stringify(response.body));
+      config.core.debug(JSON.stringify(response.body));
+    } catch (/** @type {any} */ err) {
+      config.core.setOutput("ok", false);
+      config.core.setOutput("response", JSON.stringify(err.message));
+      config.core.debug(err);
+      throw new SlackError(config.core, err.message);
+    }
+  }
+
+  /**
+   * Invoke a webhook send with retries, aborting on non-retryable errors.
+   * @template T
+   * @param {Config} config
+   * @param {() => Promise<T>} attempt - the SDK send call to retry.
+   * @returns {Promise<T>}
+   */
+  async send(config, attempt) {
+    return await pRetry(async () => {
+      try {
+        return await attempt();
+      } catch (/** @type {any} */ err) {
+        if (this.retryable(err)) {
+          throw err;
+        }
+        throw new AbortError(err);
+      }
+    }, this.retries(config.inputs.retries));
+  }
+
+  /**
+   * Decide if a @slack/webhook error should be retried.
+   *
+   * Request errors (no response received) are always retried; HTTP errors are
+   * retried only for rate limits and server errors.
+   * @param {any} err
+   * @returns {boolean}
+   */
+  retryable(err) {
+    if (err?.code === ErrorCode.RequestError) {
+      return true;
+    }
+    if (err?.code === ErrorCode.HTTPError) {
+      const status = err?.original?.response?.status;
+      return status === 429 || (status >= 500 && status <= 599);
+    }
+    return true;
+  }
+
+  /**
+   * Return configurations for https proxy options if these are set.
+   * @param {Config} config
+   * @returns {{ httpsAgent: HttpsProxyAgent<string> } | undefined}
+   * @see {@link https://github.com/slackapi/slack-github-action/pull/205}
    */
   proxies(config) {
-    const { webhook, proxy } = config.inputs;
-    if (!webhook) {
-      throw new SlackError(config.core, "No webhook was provided to proxy to");
-    }
-    if (!proxy) {
-      return undefined;
-    }
+    const proxy = config.inputs.proxy;
     try {
-      if (new URL(webhook).protocol !== "https:") {
-        config.core.debug(
-          "The webhook destination is not HTTPS so skipping the HTTPS proxy",
-        );
+      if (!proxy) {
         return undefined;
       }
-      switch (new URL(proxy).protocol) {
-        case "https:":
-          return {
-            httpsAgent: new HttpsProxyAgent(proxy),
-          };
-        case "http:":
-          return {
-            httpsAgent: new HttpsProxyAgent(proxy),
-            proxy: false,
-          };
-        default:
-          throw new SlackError(
-            config.core,
-            `Unsupported URL protocol: ${proxy}`,
-          );
-      }
+      return {
+        httpsAgent: new HttpsProxyAgent(proxy),
+      };
     } catch (/** @type {any} */ err) {
       throw new SlackError(config.core, "Failed to configure the HTTPS proxy", {
         cause: err,
@@ -86,38 +142,22 @@ export default class Webhook {
   }
 
   /**
-   * Return configurations for retry options with different delays.
-   * @param {string} option
-   * @returns {import("axios-retry").IAxiosRetryConfig}
+   * Map the retries input to a p-retry / node-retry policy.
+   * @param {string} [option]
+   * @returns {import("@slack/web-api").RetryOptions}
    */
   retries(option) {
     switch (option?.trim().toUpperCase()) {
       case "0":
         return { retries: 0 };
       case "5":
-        return {
-          retryCondition: axiosRetry.isRetryableError,
-          retries: 5,
-          retryDelay: linearDelay(60 * 1000), // 5 minutes
-        };
+        return webapi.retryPolicies.fiveRetriesInFiveMinutes;
       case "10":
-        return {
-          retryCondition: axiosRetry.isRetryableError,
-          retries: 10,
-          retryDelay: (count, err) => exponentialDelay(count, err, 2 * 1000), // 34.12 minutes
-        };
+        return webapi.retryPolicies.tenRetriesInAboutThirtyMinutes;
       case "RAPID":
-        return {
-          retryCondition: axiosRetry.isRetryableError,
-          retries: 12,
-          retryDelay: linearDelay(1 * 1000), // 12 seconds
-        };
+        return webapi.retryPolicies.rapidRetryPolicy;
       default:
-        return {
-          retryCondition: axiosRetry.isRetryableError,
-          retries: 5,
-          retryDelay: linearDelay(60 * 1000), // 5 minutes
-        };
+        return webapi.retryPolicies.fiveRetriesInFiveMinutes;
     }
   }
 }

--- a/src/webhook.js
+++ b/src/webhook.js
@@ -72,9 +72,18 @@ export default class Webhook {
    * @see {@link https://github.com/slackapi/slack-github-action/pull/205}
    */
   proxies(config) {
-    const proxy = config.inputs.proxy;
+    const { webhook, proxy } = config.inputs;
+    if (!webhook) {
+      throw new SlackError(config.core, "No webhook was provided to proxy to");
+    }
+    if (!proxy) {
+      return undefined;
+    }
     try {
-      if (!proxy) {
+      if (new URL(webhook).protocol !== "https:") {
+        config.core.debug(
+          "The webhook destination is not HTTPS so skipping the HTTPS proxy",
+        );
         return undefined;
       }
       switch (new URL(proxy).protocol) {

--- a/src/webhook.js
+++ b/src/webhook.js
@@ -1,13 +1,20 @@
-import webapi from "@slack/web-api";
-import { ErrorCode, IncomingWebhook, WebhookTrigger } from "@slack/webhook";
+import {
+  fiveRetriesInFiveMinutes,
+  IncomingWebhook,
+  rapidRetryPolicy,
+  tenRetriesInAboutThirtyMinutes,
+  WebhookTrigger,
+} from "@slack/webhook";
 import { HttpsProxyAgent } from "https-proxy-agent";
-import pRetry, { AbortError } from "p-retry";
 import Config from "./config.js";
 import SlackError from "./errors.js";
 
 /**
  * The Webhook class posts the configured payload to the provided webhook using
  * the @slack/webhook SDK, choosing the client by the configured webhook type.
+ *
+ * Retries are delegated to the SDK via the retryConfig option, matching how
+ * the API-method technique passes retryConfig to @slack/web-api's WebClient.
  *
  * @see {@link https://docs.slack.dev/tools/node-slack-sdk/webhook/}
  */
@@ -39,12 +46,13 @@ export default class Webhook {
   async postIncomingWebhook(config) {
     const webhook = new IncomingWebhook(
       /** @type {string} */ (config.inputs.webhook),
-      { agent: this.proxies(config)?.httpsAgent },
+      {
+        agent: this.proxies(config)?.httpsAgent,
+        retryConfig: this.retries(config.inputs.retries),
+      },
     );
     try {
-      const response = await this.send(config, () =>
-        webhook.send(config.content.values),
-      );
+      const response = await webhook.send(config.content.values);
       config.core.setOutput("ok", true);
       config.core.setOutput("response", JSON.stringify(response.text));
       config.core.debug(JSON.stringify(response.text));
@@ -63,12 +71,13 @@ export default class Webhook {
   async postWebhookTrigger(config) {
     const trigger = new WebhookTrigger(
       /** @type {string} */ (config.inputs.webhook),
-      { agent: this.proxies(config)?.httpsAgent },
+      {
+        agent: this.proxies(config)?.httpsAgent,
+        retryConfig: this.retries(config.inputs.retries),
+      },
     );
     try {
-      const response = await this.send(config, () =>
-        trigger.send(config.content.values),
-      );
+      const response = await trigger.send(config.content.values);
       config.core.setOutput("ok", response.ok);
       config.core.setOutput("response", JSON.stringify(response.body));
       config.core.debug(JSON.stringify(response.body));
@@ -78,45 +87,6 @@ export default class Webhook {
       config.core.debug(err);
       throw new SlackError(config.core, err.message);
     }
-  }
-
-  /**
-   * Invoke a webhook send with retries, aborting on non-retryable errors.
-   * @template T
-   * @param {Config} config
-   * @param {() => Promise<T>} attempt - the SDK send call to retry.
-   * @returns {Promise<T>}
-   */
-  async send(config, attempt) {
-    return await pRetry(async () => {
-      try {
-        return await attempt();
-      } catch (/** @type {any} */ err) {
-        if (this.retryable(err)) {
-          throw err;
-        }
-        throw new AbortError(err);
-      }
-    }, this.retries(config.inputs.retries));
-  }
-
-  /**
-   * Decide if a @slack/webhook error should be retried.
-   *
-   * Request errors (no response received) are always retried; HTTP errors are
-   * retried only for rate limits and server errors.
-   * @param {any} err
-   * @returns {boolean}
-   */
-  retryable(err) {
-    if (err?.code === ErrorCode.RequestError) {
-      return true;
-    }
-    if (err?.code === ErrorCode.HTTPError) {
-      const status = err?.original?.response?.status;
-      return status === 429 || (status >= 500 && status <= 599);
-    }
-    return true;
   }
 
   /**
@@ -142,22 +112,22 @@ export default class Webhook {
   }
 
   /**
-   * Map the retries input to a p-retry / node-retry policy.
+   * Map the retries input to a @slack/webhook retry policy.
    * @param {string} [option]
-   * @returns {import("@slack/web-api").RetryOptions}
+   * @returns {import("@slack/webhook").RetryOptions}
    */
   retries(option) {
     switch (option?.trim().toUpperCase()) {
       case "0":
         return { retries: 0 };
       case "5":
-        return webapi.retryPolicies.fiveRetriesInFiveMinutes;
+        return fiveRetriesInFiveMinutes;
       case "10":
-        return webapi.retryPolicies.tenRetriesInAboutThirtyMinutes;
+        return tenRetriesInAboutThirtyMinutes;
       case "RAPID":
-        return webapi.retryPolicies.rapidRetryPolicy;
+        return rapidRetryPolicy;
       default:
-        return webapi.retryPolicies.fiveRetriesInFiveMinutes;
+        return fiveRetriesInFiveMinutes;
     }
   }
 }

--- a/src/webhook.js
+++ b/src/webhook.js
@@ -9,10 +9,8 @@ import SlackError from "./errors.js";
 
 /**
  * The Webhook class posts the configured payload to the provided webhook using
- * the @slack/webhook SDK, choosing the client by the configured webhook type.
- *
- * Retries are delegated to the SDK via the retryConfig option, matching how
- * the API-method technique passes retryConfig to @slack/web-api's WebClient.
+ * the @slack/webhook package, choosing the client by the configured webhook
+ * type, with whatever additional settings set.
  *
  * @see {@link https://docs.slack.dev/tools/node-slack-sdk/webhook/}
  */

--- a/src/webhook.js
+++ b/src/webhook.js
@@ -69,6 +69,7 @@ export default class Webhook {
    * Return configurations for https proxy options if these are set.
    * @param {Config} config
    * @returns {{ httpsAgent: HttpsProxyAgent<string> } | undefined}
+   * @see {@link https://github.com/slackapi/slack-github-action/pull/132}
    * @see {@link https://github.com/slackapi/slack-github-action/pull/205}
    */
   proxies(config) {

--- a/src/webhook.js
+++ b/src/webhook.js
@@ -1,8 +1,4 @@
-import {
-  fiveRetriesInFiveMinutes,
-  rapidRetryPolicy,
-  tenRetriesInAboutThirtyMinutes,
-} from "@slack/webhook";
+import webhook from "@slack/webhook";
 import { HttpsProxyAgent } from "https-proxy-agent";
 import Config from "./config.js";
 import SlackError from "./errors.js";
@@ -111,13 +107,13 @@ export default class Webhook {
       case "0":
         return { retries: 0 };
       case "5":
-        return fiveRetriesInFiveMinutes;
+        return webhook.retryPolicies.fiveRetriesInFiveMinutes;
       case "10":
-        return tenRetriesInAboutThirtyMinutes;
+        return webhook.retryPolicies.tenRetriesInAboutThirtyMinutes;
       case "RAPID":
-        return rapidRetryPolicy;
+        return webhook.retryPolicies.rapidRetryPolicy;
       default:
-        return fiveRetriesInFiveMinutes;
+        return webhook.retryPolicies.fiveRetriesInFiveMinutes;
     }
   }
 }

--- a/src/webhook.js
+++ b/src/webhook.js
@@ -8,9 +8,8 @@ import Config from "./config.js";
 import SlackError from "./errors.js";
 
 /**
- * The Webhook class posts the configured payload to the provided webhook using
- * the @slack/webhook package, choosing the client by the configured webhook
- * type, with whatever additional settings set.
+ * This Webhook class posts the configured payload to the provided webhook, with
+ * whatever additional settings set.
  *
  * @see {@link https://docs.slack.dev/tools/node-slack-sdk/webhook/}
  */

--- a/src/webhook.js
+++ b/src/webhook.js
@@ -97,8 +97,8 @@ export default class Webhook {
   }
 
   /**
-   * Map the retries input to a @slack/webhook retry policy.
-   * @param {string} [option]
+   * Return configurations for retry options with different delays.
+   * @param {string} option
    * @returns {import("@slack/webhook").RetryOptions}
    */
   retries(option) {

--- a/src/webhook.js
+++ b/src/webhook.js
@@ -66,7 +66,7 @@ export default class Webhook {
   }
 
   /**
-   * Return an https proxy agent if a proxy is set.
+   * Return configurations for http proxy options if these are set.
    * @param {Config} config
    * @returns {HttpsProxyAgent<string> | undefined}
    * @see {@link https://github.com/slackapi/slack-github-action/pull/132}

--- a/src/webhook.js
+++ b/src/webhook.js
@@ -1,9 +1,7 @@
 import {
   fiveRetriesInFiveMinutes,
-  IncomingWebhook,
   rapidRetryPolicy,
   tenRetriesInAboutThirtyMinutes,
-  WebhookTrigger,
 } from "@slack/webhook";
 import { HttpsProxyAgent } from "https-proxy-agent";
 import Config from "./config.js";
@@ -26,61 +24,39 @@ export default class Webhook {
     if (!config.inputs.webhook) {
       throw new SlackError(config.core, "No webhook was provided to post to");
     }
-    switch (config.inputs.webhookType) {
-      case "incoming-webhook":
-        return await this.postIncomingWebhook(config);
-      case "webhook-trigger":
-        return await this.postWebhookTrigger(config);
-      default:
-        throw new SlackError(
-          config.core,
-          `Unknown webhook type: ${config.inputs.webhookType}`,
-        );
-    }
-  }
-
-  /**
-   * Post using the @slack/webhook IncomingWebhook client.
-   * @param {Config} config
-   */
-  async postIncomingWebhook(config) {
-    const webhook = new IncomingWebhook(
-      /** @type {string} */ (config.inputs.webhook),
-      {
-        agent: this.proxies(config)?.httpsAgent,
-        retryConfig: this.retries(config.inputs.retries),
-      },
-    );
+    const url = config.inputs.webhook;
+    const options = {
+      agent: this.proxies(config)?.httpsAgent,
+      retryConfig: this.retries(config.inputs.retries),
+    };
     try {
-      const response = await webhook.send(config.content.values);
-      config.core.setOutput("ok", true);
-      config.core.setOutput("response", JSON.stringify(response.text));
-      config.core.debug(JSON.stringify(response.text));
-    } catch (/** @type {any} */ err) {
-      config.core.setOutput("ok", false);
-      config.core.setOutput("response", JSON.stringify(err.message));
-      config.core.debug(err);
-      throw new SlackError(config.core, err.message);
-    }
-  }
-
-  /**
-   * Post using the @slack/webhook WebhookTrigger client.
-   * @param {Config} config
-   */
-  async postWebhookTrigger(config) {
-    const trigger = new WebhookTrigger(
-      /** @type {string} */ (config.inputs.webhook),
-      {
-        agent: this.proxies(config)?.httpsAgent,
-        retryConfig: this.retries(config.inputs.retries),
-      },
-    );
-    try {
-      const response = await trigger.send(config.content.values);
-      config.core.setOutput("ok", response.ok);
-      config.core.setOutput("response", JSON.stringify(response.body));
-      config.core.debug(JSON.stringify(response.body));
+      switch (config.inputs.webhookType) {
+        case "incoming-webhook": {
+          const response = await new config.webhook.IncomingWebhook(
+            url,
+            options,
+          ).send(config.content.values);
+          config.core.setOutput("ok", true);
+          config.core.setOutput("response", JSON.stringify(response.text));
+          config.core.debug(JSON.stringify(response.text));
+          break;
+        }
+        case "webhook-trigger": {
+          const response = await new config.webhook.WebhookTrigger(
+            url,
+            options,
+          ).send(config.content.values);
+          config.core.setOutput("ok", response.ok);
+          config.core.setOutput("response", JSON.stringify(response.body));
+          config.core.debug(JSON.stringify(response.body));
+          break;
+        }
+        default:
+          throw new SlackError(
+            config.core,
+            `Unknown webhook type: ${config.inputs.webhookType}`,
+          );
+      }
     } catch (/** @type {any} */ err) {
       config.core.setOutput("ok", false);
       config.core.setOutput("response", JSON.stringify(err.message));

--- a/src/webhook.js
+++ b/src/webhook.js
@@ -40,8 +40,8 @@ export default class Webhook {
             options,
           ).send(config.content.values);
           config.core.setOutput("ok", response.ok);
-          config.core.setOutput("response", JSON.stringify(response.body));
-          config.core.debug(JSON.stringify(response.body));
+          config.core.setOutput("response", JSON.stringify(response));
+          config.core.debug(JSON.stringify(response));
           return;
         }
         default:

--- a/src/webhook.js
+++ b/src/webhook.js
@@ -39,7 +39,7 @@ export default class Webhook {
           config.core.setOutput("ok", true);
           config.core.setOutput("response", JSON.stringify(response.text));
           config.core.debug(JSON.stringify(response.text));
-          break;
+          return;
         }
         case "webhook-trigger": {
           const response = await new config.webhook.WebhookTrigger(
@@ -49,7 +49,7 @@ export default class Webhook {
           config.core.setOutput("ok", response.ok);
           config.core.setOutput("response", JSON.stringify(response.body));
           config.core.debug(JSON.stringify(response.body));
-          break;
+          return;
         }
         default:
           throw new SlackError(

--- a/test/client.spec.js
+++ b/test/client.spec.js
@@ -492,14 +492,14 @@ describe("client", () => {
     });
 
     it('does not attempt retries when "0" is set', async () => {
-      const webhook = new Client();
-      const result = webhook.retries("0");
+      const client = new Client();
+      const result = client.retries("0");
       assert.equal(result.retries, 0);
     });
 
     it('attempts a default amount of "5" retries', async () => {
-      const webhook = new Client();
-      const result = webhook.retries("5");
+      const client = new Client();
+      const result = client.retries("5");
       assert.equal(
         result.retries,
         webapi.retryPolicies.fiveRetriesInFiveMinutes.retries,
@@ -511,8 +511,8 @@ describe("client", () => {
     });
 
     it('attempts "10" retries in around "30" minutes', async () => {
-      const webhook = new Client();
-      const result = webhook.retries("10");
+      const client = new Client();
+      const result = client.retries("10");
       assert.equal(
         result.retries,
         webapi.retryPolicies.tenRetriesInAboutThirtyMinutes.retries,
@@ -524,8 +524,8 @@ describe("client", () => {
     });
 
     it('attempts a "rapid " burst of "12" retries in seconds', async () => {
-      const webhook = new Client();
-      const result = webhook.retries("rapid ");
+      const client = new Client();
+      const result = client.retries("rapid ");
       assert.equal(
         result.retries,
         webapi.retryPolicies.rapidRetryPolicy.retries,
@@ -534,8 +534,8 @@ describe("client", () => {
     });
 
     it('attempts a "RAPID" burst of "12" retries in seconds', async () => {
-      const webhook = new Client();
-      const result = webhook.retries("RAPID");
+      const client = new Client();
+      const result = client.retries("RAPID");
       assert.equal(
         result.retries,
         webapi.retryPolicies.rapidRetryPolicy.retries,

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -184,19 +184,19 @@ describe("config", () => {
       }
     });
 
-    it("adds metadata to webhook with package name and version", async () => {
+    it("adds web-api app metadata with package name and version", async () => {
       mocks.core.getInput.withArgs("method").returns("chat.postMessage");
       mocks.core.getInput.withArgs("token").returns("xoxb-example");
-      const config = new Config(mocks.core);
-      assert.ok(
-        config.axios.defaults.headers.common["User-Agent"].startsWith(
-          "@slack:slack-github-action/",
-        ),
-      );
-      assert.ok(
-        config.axios.defaults.headers.common["User-Agent"].length >
-          "@slack:slack-github-action/".length,
-      );
+      const addAppMetadata = mocks.sandbox.stub(webapi, "addAppMetadata");
+      try {
+        new Config(mocks.core);
+        assert.ok(addAppMetadata.called, "addAppMetadata was not called");
+        const arg = addAppMetadata.getCall(0).firstArg;
+        assert.ok(arg.name.includes("slack-github-action"));
+        assert.ok(arg.version.length > 0);
+      } finally {
+        addAppMetadata.restore();
+      }
     });
   });
 
@@ -225,7 +225,7 @@ describe("config", () => {
 
   describe("validate", () => {
     it('allow the "retries" option with lowercased space', async () => {
-      mocks.axios.post.returns(Promise.resolve("LGTM"));
+      mocks.incomingWebhook.resolves({ text: "LGTM" });
       mocks.core.getInput.withArgs("retries").returns(" rapid ");
       mocks.core.getInput
         .withArgs("webhook")
@@ -247,7 +247,7 @@ describe("config", () => {
     });
 
     it("errors if an invalid retries option is provided", async () => {
-      mocks.axios.post.returns(Promise.resolve("LGTM"));
+      mocks.incomingWebhook.resolves({ text: "LGTM" });
       mocks.core.getInput.withArgs("retries").returns("FOREVER");
       mocks.core.getInput
         .withArgs("webhook")

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -196,8 +196,12 @@ describe("config", () => {
         configurable: true,
       });
       try {
-        mocks.core.getInput.withArgs("method").returns("chat.postMessage");
-        mocks.core.getInput.withArgs("token").returns("xoxb-example");
+        mocks.core.getInput
+          .withArgs("webhook")
+          .returns("https://hooks.slack.com");
+        mocks.core.getInput
+          .withArgs("webhook-type")
+          .returns("incoming-webhook");
         new Config(mocks.core);
         assert.ok(stub.calledOnce);
         const { name, version } = stub.firstCall.args[0];

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -183,7 +183,6 @@ describe("config", () => {
         Object.defineProperty(webapi, "addAppMetadata", original);
       }
     });
-
   });
 
   describe("mask", async () => {

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -1,6 +1,7 @@
 import assert from "node:assert";
 import { beforeEach, describe, it } from "node:test";
 import webapi from "@slack/web-api";
+import webhook from "@slack/webhook";
 import sinon from "sinon";
 import Config from "../src/config.js";
 import SlackError from "../src/errors.js";
@@ -181,6 +182,29 @@ describe("config", () => {
         assert.ok(version);
       } finally {
         Object.defineProperty(webapi, "addAppMetadata", original);
+      }
+    });
+
+    it("adds metadata to webhook with package name and version", async () => {
+      const stub = sinon.stub();
+      const original = Object.getOwnPropertyDescriptor(
+        webhook,
+        "addAppMetadata",
+      );
+      Object.defineProperty(webhook, "addAppMetadata", {
+        value: stub,
+        configurable: true,
+      });
+      try {
+        mocks.core.getInput.withArgs("method").returns("chat.postMessage");
+        mocks.core.getInput.withArgs("token").returns("xoxb-example");
+        new Config(mocks.core);
+        assert.ok(stub.calledOnce);
+        const { name, version } = stub.firstCall.args[0];
+        assert.equal(name, "@slack/slack-github-action");
+        assert.ok(version);
+      } finally {
+        Object.defineProperty(webhook, "addAppMetadata", original);
       }
     });
   });

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -184,20 +184,6 @@ describe("config", () => {
       }
     });
 
-    it("adds web-api app metadata with package name and version", async () => {
-      mocks.core.getInput.withArgs("method").returns("chat.postMessage");
-      mocks.core.getInput.withArgs("token").returns("xoxb-example");
-      const addAppMetadata = mocks.sandbox.stub(webapi, "addAppMetadata");
-      try {
-        new Config(mocks.core);
-        assert.ok(addAppMetadata.called, "addAppMetadata was not called");
-        const arg = addAppMetadata.getCall(0).firstArg;
-        assert.ok(arg.name.includes("slack-github-action"));
-        assert.ok(arg.version.length > 0);
-      } finally {
-        addAppMetadata.restore();
-      }
-    });
   });
 
   describe("mask", async () => {

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -234,7 +234,7 @@ describe("config", () => {
 
   describe("validate", () => {
     it('allow the "retries" option with lowercased space', async () => {
-      mocks.incomingWebhook.resolves({ text: "LGTM" });
+      mocks.webhook.incoming.resolves({ text: "LGTM" });
       mocks.core.getInput.withArgs("retries").returns(" rapid ");
       mocks.core.getInput
         .withArgs("webhook")
@@ -256,7 +256,7 @@ describe("config", () => {
     });
 
     it("errors if an invalid retries option is provided", async () => {
-      mocks.incomingWebhook.resolves({ text: "LGTM" });
+      mocks.webhook.incoming.resolves({ text: "LGTM" });
       mocks.core.getInput.withArgs("retries").returns("FOREVER");
       mocks.core.getInput
         .withArgs("webhook")

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,7 +1,6 @@
 import fs from "node:fs";
 import webapi from "@slack/web-api";
 import { IncomingWebhook, WebhookTrigger } from "@slack/webhook";
-import { AxiosError } from "axios";
 import sinon from "sinon";
 
 /**
@@ -20,21 +19,6 @@ import sinon from "sinon";
  * The Mock class sets expected behaviors and test listeners for dependencies.
  */
 export class Mock {
-  /**
-   * @typedef Errors - A collection of mocked errors to use in tests.
-   * @prop {Object.<string, AxiosError>} axios - The mocked axios errors.
-   */
-
-  /**
-   * The mocked errors.
-   * @type {Errors}
-   */
-  errors = {
-    axios: {
-      network_failed: new AxiosError("network_failed"),
-    },
-  };
-
   /**
    * Setup stubbed dependencies and configure default input arguments for all
    * tests.

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -27,8 +27,10 @@ export class Mock {
    */
   constructor() {
     this.sandbox = sinon.createSandbox();
-    this.incomingWebhook = this.sandbox.stub(IncomingWebhook.prototype, "send");
-    this.webhookTrigger = this.sandbox.stub(WebhookTrigger.prototype, "send");
+    this.webhook = {
+      incoming: this.sandbox.stub(IncomingWebhook.prototype, "send"),
+      trigger: this.sandbox.stub(WebhookTrigger.prototype, "send"),
+    };
     this.calls = this.sandbox.stub(webapi.WebClient.prototype, "apiCall");
     this.core = {
       debug: this.sandbox.stub(),
@@ -59,8 +61,8 @@ export class Mock {
    */
   reset() {
     this.sandbox.reset();
-    this.incomingWebhook.resetHistory();
-    this.webhookTrigger.resetHistory();
+    this.webhook.incoming.resetHistory();
+    this.webhook.trigger.resetHistory();
     this.calls.resetHistory();
     this.core.debug.reset();
     this.core.error.reset();

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -27,10 +27,6 @@ export class Mock {
    */
   constructor() {
     this.sandbox = sinon.createSandbox();
-    this.webhook = {
-      incoming: this.sandbox.stub(webhook.IncomingWebhook.prototype, "send"),
-      trigger: this.sandbox.stub(webhook.WebhookTrigger.prototype, "send"),
-    };
     this.calls = this.sandbox.stub(webapi.WebClient.prototype, "apiCall");
     this.core = {
       debug: this.sandbox.stub(),
@@ -52,6 +48,10 @@ export class Mock {
         });
       },
     };
+    this.webhook = {
+      incoming: this.sandbox.stub(webhook.IncomingWebhook.prototype, "send"),
+      trigger: this.sandbox.stub(webhook.WebhookTrigger.prototype, "send"),
+    };
     this.core.getInput.withArgs("errors").returns("false");
     this.core.getInput.withArgs("retries").returns("5");
   }
@@ -61,8 +61,6 @@ export class Mock {
    */
   reset() {
     this.sandbox.reset();
-    this.webhook.incoming.resetHistory();
-    this.webhook.trigger.resetHistory();
     this.calls.resetHistory();
     this.core.debug.reset();
     this.core.error.reset();
@@ -81,6 +79,8 @@ export class Mock {
         });
       },
     };
+    this.webhook.incoming.resetHistory();
+    this.webhook.trigger.resetHistory();
     this.core.getInput.withArgs("errors").returns("false");
     this.core.getInput.withArgs("retries").returns("5");
     process.env.SLACK_TOKEN = "";

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import webapi from "@slack/web-api";
-import { IncomingWebhook, WebhookTrigger } from "@slack/webhook";
+import webhook from "@slack/webhook";
 import sinon from "sinon";
 
 /**
@@ -28,8 +28,8 @@ export class Mock {
   constructor() {
     this.sandbox = sinon.createSandbox();
     this.webhook = {
-      incoming: this.sandbox.stub(IncomingWebhook.prototype, "send"),
-      trigger: this.sandbox.stub(WebhookTrigger.prototype, "send"),
+      incoming: this.sandbox.stub(webhook.IncomingWebhook.prototype, "send"),
+      trigger: this.sandbox.stub(webhook.WebhookTrigger.prototype, "send"),
     };
     this.calls = this.sandbox.stub(webapi.WebClient.prototype, "apiCall");
     this.core = {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import webapi from "@slack/web-api";
-import axios, { AxiosError } from "axios";
+import { IncomingWebhook, WebhookTrigger } from "@slack/webhook";
+import { AxiosError } from "axios";
 import sinon from "sinon";
 
 /**
@@ -42,7 +43,8 @@ export class Mock {
    */
   constructor() {
     this.sandbox = sinon.createSandbox();
-    this.axios = this.sandbox.stub(axios);
+    this.incomingWebhook = this.sandbox.stub(IncomingWebhook.prototype, "send");
+    this.webhookTrigger = this.sandbox.stub(WebhookTrigger.prototype, "send");
     this.calls = this.sandbox.stub(webapi.WebClient.prototype, "apiCall");
     this.core = {
       debug: this.sandbox.stub(),
@@ -73,7 +75,8 @@ export class Mock {
    */
   reset() {
     this.sandbox.reset();
-    this.axios.post.resetHistory();
+    this.incomingWebhook.resetHistory();
+    this.webhookTrigger.resetHistory();
     this.calls.resetHistory();
     this.core.debug.reset();
     this.core.error.reset();

--- a/test/send.spec.js
+++ b/test/send.spec.js
@@ -24,9 +24,7 @@ describe("send", () => {
         .returns("https://hooks.slack.com");
       mocks.core.getInput.withArgs("webhook-type").returns("webhook-trigger");
       mocks.core.getInput.withArgs("payload").returns('"greetings": "hello"');
-      mocks.axios.post.returns(
-        Promise.resolve({ status: 200, data: { ok: true } }),
-      );
+      mocks.webhookTrigger.resolves({ ok: true, body: { ok: true } });
       await send(mocks.core);
       assert.equal(mocks.core.setOutput.getCall(0).firstArg, "ok");
       assert.equal(mocks.core.setOutput.getCall(0).lastArg, true);
@@ -64,7 +62,7 @@ describe("send", () => {
         .returns("https://hooks.slack.com");
       mocks.core.getInput.withArgs("webhook-type").returns("incoming-webhook");
       mocks.core.getInput.withArgs("payload").returns('"text": "hello"');
-      mocks.axios.post.returns(Promise.resolve({ status: 200, data: "ok" }));
+      mocks.incomingWebhook.resolves({ text: "ok" });
       await send(mocks.core);
       assert.equal(mocks.core.setOutput.getCall(0).firstArg, "ok");
       assert.equal(mocks.core.setOutput.getCall(0).lastArg, true);

--- a/test/send.spec.js
+++ b/test/send.spec.js
@@ -24,7 +24,7 @@ describe("send", () => {
         .returns("https://hooks.slack.com");
       mocks.core.getInput.withArgs("webhook-type").returns("webhook-trigger");
       mocks.core.getInput.withArgs("payload").returns('"greetings": "hello"');
-      mocks.webhookTrigger.resolves({ ok: true, body: { ok: true } });
+      mocks.webhook.trigger.resolves({ ok: true, body: { ok: true } });
       await send(mocks.core);
       assert.equal(mocks.core.setOutput.getCall(0).firstArg, "ok");
       assert.equal(mocks.core.setOutput.getCall(0).lastArg, true);
@@ -62,7 +62,7 @@ describe("send", () => {
         .returns("https://hooks.slack.com");
       mocks.core.getInput.withArgs("webhook-type").returns("incoming-webhook");
       mocks.core.getInput.withArgs("payload").returns('"text": "hello"');
-      mocks.incomingWebhook.resolves({ text: "ok" });
+      mocks.webhook.incoming.resolves({ text: "ok" });
       await send(mocks.core);
       assert.equal(mocks.core.setOutput.getCall(0).firstArg, "ok");
       assert.equal(mocks.core.setOutput.getCall(0).lastArg, true);

--- a/test/send.spec.js
+++ b/test/send.spec.js
@@ -24,7 +24,7 @@ describe("send", () => {
         .returns("https://hooks.slack.com");
       mocks.core.getInput.withArgs("webhook-type").returns("webhook-trigger");
       mocks.core.getInput.withArgs("payload").returns('"greetings": "hello"');
-      mocks.webhook.trigger.resolves({ ok: true, body: { ok: true } });
+      mocks.webhook.trigger.resolves({ ok: true });
       await send(mocks.core);
       assert.equal(mocks.core.setOutput.getCall(0).firstArg, "ok");
       assert.equal(mocks.core.setOutput.getCall(0).lastArg, true);

--- a/test/webhook.spec.js
+++ b/test/webhook.spec.js
@@ -19,7 +19,7 @@ describe("webhook", () => {
         .returns("https://hooks.slack.com");
       mocks.core.getInput.withArgs("webhook-type").returns("webhook-trigger");
       mocks.core.getInput.withArgs("payload").returns("drinks: coffee");
-      mocks.webhook.trigger.resolves({ ok: true, body: { ok: true } });
+      mocks.webhook.trigger.resolves({ ok: true });
       try {
         await send(mocks.core);
         assert.equal(mocks.webhook.trigger.getCalls().length, 1);

--- a/test/webhook.spec.js
+++ b/test/webhook.spec.js
@@ -88,36 +88,6 @@ describe("webhook", () => {
     });
 
     it("returns the failures from a webhook trigger", async () => {
-      mocks.core.getInput
-        .withArgs("webhook")
-        .returns("https://hooks.slack.com");
-      mocks.core.getInput.withArgs("webhook-type").returns("webhook-trigger");
-      mocks.core.getInput.withArgs("payload").returns("drinks: coffee");
-      mocks.webhook.trigger.rejects(
-        new Error("An HTTP protocol error occurred"),
-      );
-      await send(mocks.core);
-      assert.equal(mocks.webhook.trigger.getCalls().length, 1);
-      assert.equal(mocks.core.setOutput.getCall(0).firstArg, "ok");
-      assert.equal(mocks.core.setOutput.getCall(0).lastArg, false);
-    });
-
-    it("returns the failures from an incoming webhook", async () => {
-      mocks.core.getInput
-        .withArgs("webhook")
-        .returns("https://hooks.slack.com");
-      mocks.core.getInput.withArgs("webhook-type").returns("incoming-webhook");
-      mocks.core.getInput.withArgs("payload").returns("text: hi");
-      mocks.webhook.incoming.rejects(
-        new Error("An HTTP protocol error occurred"),
-      );
-      await send(mocks.core);
-      assert.equal(mocks.webhook.incoming.getCalls().length, 1);
-      assert.equal(mocks.core.setOutput.getCall(0).firstArg, "ok");
-      assert.equal(mocks.core.setOutput.getCall(0).lastArg, false);
-    });
-
-    it('throws the failure when the "errors" input is enabled', async () => {
       mocks.core.getBooleanInput.withArgs("errors").returns(true);
       mocks.core.getInput
         .withArgs("webhook")
@@ -137,7 +107,36 @@ describe("webhook", () => {
           assert.fail(err);
         }
       }
-      assert.equal(mocks.core.setFailed.getCalls().length, 1);
+      assert.equal(mocks.webhook.trigger.getCalls().length, 1);
+      assert.ok(mocks.core.setFailed.called);
+      assert.equal(mocks.core.setOutput.getCall(0).firstArg, "ok");
+      assert.equal(mocks.core.setOutput.getCall(0).lastArg, false);
+    });
+
+    it("returns the failures from an incoming webhook", async () => {
+      mocks.core.getBooleanInput.withArgs("errors").returns(true);
+      mocks.core.getInput
+        .withArgs("webhook")
+        .returns("https://hooks.slack.com");
+      mocks.core.getInput.withArgs("webhook-type").returns("incoming-webhook");
+      mocks.core.getInput.withArgs("payload").returns("text: hi");
+      mocks.webhook.incoming.rejects(
+        new Error("An HTTP protocol error occurred"),
+      );
+      try {
+        await send(mocks.core);
+        assert.fail("An incoming webhook failure was not thrown as error!");
+      } catch (err) {
+        if (err instanceof SlackError) {
+          assert.ok(err.message.includes("An HTTP protocol error occurred"));
+        } else {
+          assert.fail(err);
+        }
+      }
+      assert.equal(mocks.webhook.incoming.getCalls().length, 1);
+      assert.ok(mocks.core.setFailed.called);
+      assert.equal(mocks.core.setOutput.getCall(0).firstArg, "ok");
+      assert.equal(mocks.core.setOutput.getCall(0).lastArg, false);
     });
   });
 

--- a/test/webhook.spec.js
+++ b/test/webhook.spec.js
@@ -293,7 +293,10 @@ describe("webhook", () => {
   describe("retries", () => {
     it("uses a default of five retries in requests", async () => {
       const result = new Webhook().retries();
-      assert.equal(result.retries, webhook.fiveRetriesInFiveMinutes.retries);
+      assert.equal(
+        result.retries,
+        webhook.retryPolicies.fiveRetriesInFiveMinutes.retries,
+      );
     });
 
     it('does not attempt retries when "0" is set', async () => {
@@ -303,32 +306,50 @@ describe("webhook", () => {
 
     it('attempts a default amount of "5" retries', async () => {
       const result = new Webhook().retries("5");
-      assert.equal(result.retries, webhook.fiveRetriesInFiveMinutes.retries);
-      assert.equal(result.factor, webhook.fiveRetriesInFiveMinutes.factor);
+      assert.equal(
+        result.retries,
+        webhook.retryPolicies.fiveRetriesInFiveMinutes.retries,
+      );
+      assert.equal(
+        result.factor,
+        webhook.retryPolicies.fiveRetriesInFiveMinutes.factor,
+      );
     });
 
     it('attempts "10" retries in around "30" minutes', async () => {
       const result = new Webhook().retries("10");
       assert.equal(
         result.retries,
-        webhook.tenRetriesInAboutThirtyMinutes.retries,
+        webhook.retryPolicies.tenRetriesInAboutThirtyMinutes.retries,
       );
       assert.equal(
         result.factor,
-        webhook.tenRetriesInAboutThirtyMinutes.factor,
+        webhook.retryPolicies.tenRetriesInAboutThirtyMinutes.factor,
       );
     });
 
     it('attempts a " rapid" burst of "12" retries in seconds', async () => {
       const result = new Webhook().retries(" rapid");
-      assert.equal(result.retries, webhook.rapidRetryPolicy.retries);
-      assert.equal(result.factor, webhook.rapidRetryPolicy.factor);
+      assert.equal(
+        result.retries,
+        webhook.retryPolicies.rapidRetryPolicy.retries,
+      );
+      assert.equal(
+        result.factor,
+        webhook.retryPolicies.rapidRetryPolicy.factor,
+      );
     });
 
     it('attempts a "RAPID" burst of "12" retries in seconds', async () => {
       const result = new Webhook().retries("RAPID");
-      assert.equal(result.retries, webhook.rapidRetryPolicy.retries);
-      assert.equal(result.factor, webhook.rapidRetryPolicy.factor);
+      assert.equal(
+        result.retries,
+        webhook.retryPolicies.rapidRetryPolicy.retries,
+      );
+      assert.equal(
+        result.factor,
+        webhook.retryPolicies.rapidRetryPolicy.factor,
+      );
     });
   });
 });

--- a/test/webhook.spec.js
+++ b/test/webhook.spec.js
@@ -100,6 +100,7 @@ describe("webhook", () => {
         await send(mocks.core);
       } catch (e) {
         assert.ok(e instanceof SlackError);
+        assert.ok(e.message.includes("An HTTP protocol error occurred"));
       }
       assert.equal(mocks.webhook.trigger.getCalls().length, 1);
       assert.equal(mocks.core.setOutput.getCall(0).firstArg, "ok");
@@ -119,6 +120,7 @@ describe("webhook", () => {
         await send(mocks.core);
       } catch (e) {
         assert.ok(e instanceof SlackError);
+        assert.ok(e.message.includes("An HTTP protocol error occurred"));
       }
       assert.equal(mocks.webhook.incoming.getCalls().length, 1);
       assert.equal(mocks.core.setOutput.getCall(0).firstArg, "ok");

--- a/test/webhook.spec.js
+++ b/test/webhook.spec.js
@@ -96,12 +96,7 @@ describe("webhook", () => {
       mocks.webhook.trigger.rejects(
         new Error("An HTTP protocol error occurred"),
       );
-      try {
-        await send(mocks.core);
-      } catch (e) {
-        assert.ok(e instanceof SlackError);
-        assert.ok(e.message.includes("An HTTP protocol error occurred"));
-      }
+      await send(mocks.core);
       assert.equal(mocks.webhook.trigger.getCalls().length, 1);
       assert.equal(mocks.core.setOutput.getCall(0).firstArg, "ok");
       assert.equal(mocks.core.setOutput.getCall(0).lastArg, false);
@@ -116,15 +111,33 @@ describe("webhook", () => {
       mocks.webhook.incoming.rejects(
         new Error("An HTTP protocol error occurred"),
       );
-      try {
-        await send(mocks.core);
-      } catch (e) {
-        assert.ok(e instanceof SlackError);
-        assert.ok(e.message.includes("An HTTP protocol error occurred"));
-      }
+      await send(mocks.core);
       assert.equal(mocks.webhook.incoming.getCalls().length, 1);
       assert.equal(mocks.core.setOutput.getCall(0).firstArg, "ok");
       assert.equal(mocks.core.setOutput.getCall(0).lastArg, false);
+    });
+
+    it('throws the failure when the "errors" input is enabled', async () => {
+      mocks.core.getBooleanInput.withArgs("errors").returns(true);
+      mocks.core.getInput
+        .withArgs("webhook")
+        .returns("https://hooks.slack.com");
+      mocks.core.getInput.withArgs("webhook-type").returns("webhook-trigger");
+      mocks.core.getInput.withArgs("payload").returns("drinks: coffee");
+      mocks.webhook.trigger.rejects(
+        new Error("An HTTP protocol error occurred"),
+      );
+      try {
+        await send(mocks.core);
+        assert.fail("A webhook trigger failure was not thrown as error!");
+      } catch (err) {
+        if (err instanceof SlackError) {
+          assert.ok(err.message.includes("An HTTP protocol error occurred"));
+        } else {
+          assert.fail(err);
+        }
+      }
+      assert.equal(mocks.core.setFailed.getCalls().length, 1);
     });
   });
 

--- a/test/webhook.spec.js
+++ b/test/webhook.spec.js
@@ -135,7 +135,7 @@ describe("webhook", () => {
       mocks.core.getInput.withArgs("proxy").returns(proxy);
       const config = new Config(mocks.core);
       const webhook = new Webhook();
-      const { httpsAgent } = webhook.proxies(config);
+      const httpsAgent = webhook.proxies(config);
       assert.deepEqual(httpsAgent.proxy, new URL(proxy));
     });
 

--- a/test/webhook.spec.js
+++ b/test/webhook.spec.js
@@ -19,18 +19,23 @@ describe("webhook", () => {
       mocks.core.getInput.withArgs("webhook-type").returns("webhook-trigger");
       mocks.core.getInput.withArgs("payload").returns("drinks: coffee");
       mocks.webhook.trigger.resolves({ ok: true, body: { ok: true } });
-      await send(mocks.core);
-      assert.equal(mocks.webhook.trigger.getCalls().length, 1);
-      assert.deepEqual(mocks.webhook.trigger.getCall(0).firstArg, {
-        drinks: "coffee",
-      });
-      assert.equal(mocks.core.setOutput.getCall(0).firstArg, "ok");
-      assert.equal(mocks.core.setOutput.getCall(0).lastArg, true);
-      assert.equal(mocks.core.setOutput.getCall(1).firstArg, "response");
-      assert.equal(
-        mocks.core.setOutput.getCall(1).lastArg,
-        JSON.stringify({ ok: true }),
-      );
+      try {
+        await send(mocks.core);
+        assert.equal(mocks.webhook.trigger.getCalls().length, 1);
+        assert.deepEqual(mocks.webhook.trigger.getCall(0).firstArg, {
+          drinks: "coffee",
+        });
+        assert.equal(mocks.core.setOutput.getCall(0).firstArg, "ok");
+        assert.equal(mocks.core.setOutput.getCall(0).lastArg, true);
+        assert.equal(mocks.core.setOutput.getCall(1).firstArg, "response");
+        assert.equal(
+          mocks.core.setOutput.getCall(1).lastArg,
+          JSON.stringify({ ok: true }),
+        );
+      } catch (err) {
+        console.error(err);
+        assert.fail("Failed to send the webhook");
+      }
     });
 
     it("sends the parsed payload to the provided incoming webhook", async () => {
@@ -40,18 +45,23 @@ describe("webhook", () => {
       mocks.core.getInput.withArgs("webhook-type").returns("incoming-webhook");
       mocks.core.getInput.withArgs("payload").returns("text: greetings");
       mocks.webhook.incoming.resolves({ text: "ok" });
-      await send(mocks.core);
-      assert.equal(mocks.webhook.incoming.getCalls().length, 1);
-      assert.deepEqual(mocks.webhook.incoming.getCall(0).firstArg, {
-        text: "greetings",
-      });
-      assert.equal(mocks.core.setOutput.getCall(0).firstArg, "ok");
-      assert.equal(mocks.core.setOutput.getCall(0).lastArg, true);
-      assert.equal(mocks.core.setOutput.getCall(1).firstArg, "response");
-      assert.equal(
-        mocks.core.setOutput.getCall(1).lastArg,
-        JSON.stringify("ok"),
-      );
+      try {
+        await send(mocks.core);
+        assert.equal(mocks.webhook.incoming.getCalls().length, 1);
+        assert.deepEqual(mocks.webhook.incoming.getCall(0).firstArg, {
+          text: "greetings",
+        });
+        assert.equal(mocks.core.setOutput.getCall(0).firstArg, "ok");
+        assert.equal(mocks.core.setOutput.getCall(0).lastArg, true);
+        assert.equal(mocks.core.setOutput.getCall(1).firstArg, "response");
+        assert.equal(
+          mocks.core.setOutput.getCall(1).lastArg,
+          JSON.stringify("ok"),
+        );
+      } catch (err) {
+        console.error(err);
+        assert.fail("Failed to send the webhook");
+      }
     });
   });
 
@@ -220,28 +230,33 @@ describe("webhook", () => {
 
   describe("retries", () => {
     it("uses a default of five retries", async () => {
-      const result = new Webhook().retries();
+      const webhook = new Webhook();
+      const result = webhook.retries();
       assert.equal(result.retries, 5);
     });
 
     it('does not attempt retries when "0" is set', async () => {
-      const result = new Webhook().retries("0");
+      const webhook = new Webhook();
+      const result = webhook.retries("0");
       assert.equal(result.retries, 0);
     });
 
     it('maps "5" to a five-retry policy', async () => {
-      const result = new Webhook().retries("5");
+      const webhook = new Webhook();
+      const result = webhook.retries("5");
       assert.equal(result.retries, 5);
     });
 
     it('maps "10" to a ten-retry policy', async () => {
-      const result = new Webhook().retries("10");
+      const webhook = new Webhook();
+      const result = webhook.retries("10");
       assert.equal(result.retries, 10);
     });
 
     it('maps "RAPID" (case/space-insensitive) to a rapid policy', async () => {
-      const rapid = new Webhook().retries("RAPID");
-      const spaced = new Webhook().retries(" rapid");
+      const webhook = new Webhook();
+      const rapid = webhook.retries("RAPID");
+      const spaced = webhook.retries(" rapid");
       assert.deepEqual(rapid, spaced);
     });
   });

--- a/test/webhook.spec.js
+++ b/test/webhook.spec.js
@@ -116,6 +116,28 @@ describe("webhook", () => {
   });
 
   describe("proxies", () => {
+    it("requires a webhook is included in the inputs", async () => {
+      /**
+       * @type {Config}
+       */
+      const config = {
+        core: mocks.core,
+        inputs: {},
+      };
+      try {
+        new Webhook().proxies(config);
+        assert.fail("Failed to throw for missing input");
+      } catch (err) {
+        if (err instanceof SlackError) {
+          assert.ok(
+            err.message.includes("No webhook was provided to proxy to"),
+          );
+        } else {
+          assert.fail(err);
+        }
+      }
+    });
+
     it("returns undefined when no proxy is set", async () => {
       mocks.core.getInput
         .withArgs("webhook")

--- a/test/webhook.spec.js
+++ b/test/webhook.spec.js
@@ -180,16 +180,6 @@ describe("webhook", () => {
       assert.strictEqual(webhook.proxies(config), undefined);
     });
 
-    it("returns undefined when no proxy is set", async () => {
-      mocks.core.getInput
-        .withArgs("webhook")
-        .returns("https://hooks.slack.com");
-      mocks.core.getInput.withArgs("webhook-type").returns("incoming-webhook");
-      const config = new Config(mocks.core);
-      const webhook = new Webhook();
-      assert.strictEqual(webhook.proxies(config), undefined);
-    });
-
     it("sets up the proxy agent for the provided https proxy", async () => {
       const proxy = "https://example.com";
       mocks.core.getInput
@@ -201,6 +191,16 @@ describe("webhook", () => {
       const webhook = new Webhook();
       const httpsAgent = webhook.proxies(config);
       assert.deepEqual(httpsAgent.proxy, new URL(proxy));
+    });
+
+    it("returns undefined when no proxy is set", async () => {
+      mocks.core.getInput
+        .withArgs("webhook")
+        .returns("https://hooks.slack.com");
+      mocks.core.getInput.withArgs("webhook-type").returns("incoming-webhook");
+      const config = new Config(mocks.core);
+      const webhook = new Webhook();
+      assert.strictEqual(webhook.proxies(config), undefined);
     });
 
     it("fails to configure proxies with an invalid proxied url", async () => {

--- a/test/webhook.spec.js
+++ b/test/webhook.spec.js
@@ -18,10 +18,10 @@ describe("webhook", () => {
         .returns("https://hooks.slack.com");
       mocks.core.getInput.withArgs("webhook-type").returns("webhook-trigger");
       mocks.core.getInput.withArgs("payload").returns("drinks: coffee");
-      mocks.webhookTrigger.resolves({ ok: true, body: { ok: true } });
+      mocks.webhook.trigger.resolves({ ok: true, body: { ok: true } });
       await send(mocks.core);
-      assert.equal(mocks.webhookTrigger.getCalls().length, 1);
-      assert.deepEqual(mocks.webhookTrigger.getCall(0).firstArg, {
+      assert.equal(mocks.webhook.trigger.getCalls().length, 1);
+      assert.deepEqual(mocks.webhook.trigger.getCall(0).firstArg, {
         drinks: "coffee",
       });
       assert.equal(mocks.core.setOutput.getCall(0).firstArg, "ok");
@@ -39,10 +39,10 @@ describe("webhook", () => {
         .returns("https://hooks.slack.com");
       mocks.core.getInput.withArgs("webhook-type").returns("incoming-webhook");
       mocks.core.getInput.withArgs("payload").returns("text: greetings");
-      mocks.incomingWebhook.resolves({ text: "ok" });
+      mocks.webhook.incoming.resolves({ text: "ok" });
       await send(mocks.core);
-      assert.equal(mocks.incomingWebhook.getCalls().length, 1);
-      assert.deepEqual(mocks.incomingWebhook.getCall(0).firstArg, {
+      assert.equal(mocks.webhook.incoming.getCalls().length, 1);
+      assert.deepEqual(mocks.webhook.incoming.getCall(0).firstArg, {
         text: "greetings",
       });
       assert.equal(mocks.core.setOutput.getCall(0).firstArg, "ok");
@@ -82,7 +82,7 @@ describe("webhook", () => {
         .returns("https://hooks.slack.com");
       mocks.core.getInput.withArgs("webhook-type").returns("webhook-trigger");
       mocks.core.getInput.withArgs("payload").returns("drinks: coffee");
-      mocks.webhookTrigger.rejects(
+      mocks.webhook.trigger.rejects(
         new Error("An HTTP protocol error occurred"),
       );
       try {
@@ -90,7 +90,7 @@ describe("webhook", () => {
       } catch (e) {
         assert.ok(e instanceof SlackError);
       }
-      assert.equal(mocks.webhookTrigger.getCalls().length, 1);
+      assert.equal(mocks.webhook.trigger.getCalls().length, 1);
       assert.equal(mocks.core.setOutput.getCall(0).firstArg, "ok");
       assert.equal(mocks.core.setOutput.getCall(0).lastArg, false);
     });
@@ -101,7 +101,7 @@ describe("webhook", () => {
         .returns("https://hooks.slack.com");
       mocks.core.getInput.withArgs("webhook-type").returns("incoming-webhook");
       mocks.core.getInput.withArgs("payload").returns("text: hi");
-      mocks.incomingWebhook.rejects(
+      mocks.webhook.incoming.rejects(
         new Error("An HTTP protocol error occurred"),
       );
       try {
@@ -109,7 +109,7 @@ describe("webhook", () => {
       } catch (e) {
         assert.ok(e instanceof SlackError);
       }
-      assert.equal(mocks.incomingWebhook.getCalls().length, 1);
+      assert.equal(mocks.webhook.incoming.getCalls().length, 1);
       assert.equal(mocks.core.setOutput.getCall(0).firstArg, "ok");
       assert.equal(mocks.core.setOutput.getCall(0).lastArg, false);
     });

--- a/test/webhook.spec.js
+++ b/test/webhook.spec.js
@@ -1,6 +1,5 @@
 import assert from "node:assert";
 import { beforeEach, describe, it } from "node:test";
-import { AxiosError } from "axios";
 import Config from "../src/config.js";
 import SlackError from "../src/errors.js";
 import send from "../src/send.js";
@@ -19,27 +18,19 @@ describe("webhook", () => {
         .returns("https://hooks.slack.com");
       mocks.core.getInput.withArgs("webhook-type").returns("webhook-trigger");
       mocks.core.getInput.withArgs("payload").returns("drinks: coffee");
-      mocks.axios.post.returns(
-        Promise.resolve({ status: 200, data: { ok: true } }),
+      mocks.webhookTrigger.resolves({ ok: true, body: { ok: true } });
+      await send(mocks.core);
+      assert.equal(mocks.webhookTrigger.getCalls().length, 1);
+      assert.deepEqual(mocks.webhookTrigger.getCall(0).firstArg, {
+        drinks: "coffee",
+      });
+      assert.equal(mocks.core.setOutput.getCall(0).firstArg, "ok");
+      assert.equal(mocks.core.setOutput.getCall(0).lastArg, true);
+      assert.equal(mocks.core.setOutput.getCall(1).firstArg, "response");
+      assert.equal(
+        mocks.core.setOutput.getCall(1).lastArg,
+        JSON.stringify({ ok: true }),
       );
-      try {
-        await send(mocks.core);
-        assert.equal(mocks.axios.post.getCalls().length, 1);
-        const [url, payload, options] = mocks.axios.post.getCall(0).args;
-        assert.equal(url, "https://hooks.slack.com");
-        assert.deepEqual(payload, { drinks: "coffee" });
-        assert.deepEqual(options, {});
-        assert.equal(mocks.core.setOutput.getCall(0).firstArg, "ok");
-        assert.equal(mocks.core.setOutput.getCall(0).lastArg, true);
-        assert.equal(mocks.core.setOutput.getCall(1).firstArg, "response");
-        assert.equal(
-          mocks.core.setOutput.getCall(1).lastArg,
-          JSON.stringify({ ok: true }),
-        );
-      } catch (err) {
-        console.error(err);
-        assert.fail("Failed to send the webhook");
-      }
     });
 
     it("sends the parsed payload to the provided incoming webhook", async () => {
@@ -48,25 +39,19 @@ describe("webhook", () => {
         .returns("https://hooks.slack.com");
       mocks.core.getInput.withArgs("webhook-type").returns("incoming-webhook");
       mocks.core.getInput.withArgs("payload").returns("text: greetings");
-      mocks.axios.post.returns(Promise.resolve({ status: 200, data: "ok" }));
-      try {
-        await send(mocks.core);
-        assert.equal(mocks.axios.post.getCalls().length, 1);
-        const [url, payload, options] = mocks.axios.post.getCall(0).args;
-        assert.equal(url, "https://hooks.slack.com");
-        assert.deepEqual(payload, { text: "greetings" });
-        assert.deepEqual(options, {});
-        assert.equal(mocks.core.setOutput.getCall(0).firstArg, "ok");
-        assert.equal(mocks.core.setOutput.getCall(0).lastArg, true);
-        assert.equal(mocks.core.setOutput.getCall(1).firstArg, "response");
-        assert.equal(
-          mocks.core.setOutput.getCall(1).lastArg,
-          JSON.stringify("ok"),
-        );
-      } catch (err) {
-        console.error(err);
-        assert.fail("Failed to send the webhook");
-      }
+      mocks.incomingWebhook.resolves({ text: "ok" });
+      await send(mocks.core);
+      assert.equal(mocks.incomingWebhook.getCalls().length, 1);
+      assert.deepEqual(mocks.incomingWebhook.getCall(0).firstArg, {
+        text: "greetings",
+      });
+      assert.equal(mocks.core.setOutput.getCall(0).firstArg, "ok");
+      assert.equal(mocks.core.setOutput.getCall(0).lastArg, true);
+      assert.equal(mocks.core.setOutput.getCall(1).firstArg, "response");
+      assert.equal(
+        mocks.core.setOutput.getCall(1).lastArg,
+        JSON.stringify("ok"),
+      );
     });
   });
 
@@ -91,108 +76,64 @@ describe("webhook", () => {
       }
     });
 
-    it("returns the failures from a webhook trigger", async () => {
+    it("does not retry a 4xx from a webhook trigger", async () => {
       mocks.core.getInput
         .withArgs("webhook")
         .returns("https://hooks.slack.com");
       mocks.core.getInput.withArgs("webhook-type").returns("webhook-trigger");
       mocks.core.getInput.withArgs("payload").returns("drinks: coffee");
-      const response = new AxiosError(
-        "Request failed with status code 400",
-        "ERR_BAD_REQUEST",
-        {},
-        {},
-        { status: 400 },
-      );
-      mocks.axios.post.resolves(Promise.reject(response));
+      mocks.core.getInput.withArgs("retries").returns("RAPID");
+      const err = Object.assign(new Error("An HTTP protocol error occurred"), {
+        code: "slack_webhook_http_error",
+        original: { response: { status: 400 } },
+      });
+      mocks.webhookTrigger.rejects(err);
       try {
         await send(mocks.core);
-      } catch (err) {
-        if (err instanceof SlackError) {
-          assert.ok(
-            err.message.includes("Request failed with status code 400"),
-          );
-        } else {
-          assert.fail(err);
-        }
+      } catch (e) {
+        assert.ok(e instanceof SlackError);
       }
-      assert.equal(mocks.axios.post.getCalls().length, 1);
-      const [url, payload, options] = mocks.axios.post.getCall(0).args;
-      assert.equal(url, "https://hooks.slack.com");
-      assert.deepEqual(payload, { drinks: "coffee" });
-      assert.deepEqual(options, {});
+      assert.equal(
+        mocks.webhookTrigger.getCalls().length,
+        1,
+        "4xx must not be retried",
+      );
       assert.equal(mocks.core.setOutput.getCall(0).firstArg, "ok");
       assert.equal(mocks.core.setOutput.getCall(0).lastArg, false);
-      assert.equal(mocks.core.setOutput.getCall(1).firstArg, "response");
     });
 
-    it("returns the failures from an incoming webhook", async () => {
+    it("retries a 5xx from an incoming webhook then succeeds", async () => {
       mocks.core.getInput
         .withArgs("webhook")
         .returns("https://hooks.slack.com");
       mocks.core.getInput.withArgs("webhook-type").returns("incoming-webhook");
-      mocks.core.getInput.withArgs("payload").returns("textt: oops");
-      const response = new AxiosError(
-        "Request failed with status code 400",
-        "ERR_BAD_REQUEST",
-        {},
-        {},
-        { status: 400 },
+      mocks.core.getInput.withArgs("payload").returns("text: hi");
+      mocks.core.getInput.withArgs("retries").returns("RAPID");
+      const err = Object.assign(new Error("An HTTP protocol error occurred"), {
+        code: "slack_webhook_http_error",
+        original: { response: { status: 503 } },
+      });
+      mocks.incomingWebhook.onFirstCall().rejects(err);
+      mocks.incomingWebhook.onSecondCall().resolves({ text: "ok" });
+      await send(mocks.core);
+      assert.equal(
+        mocks.incomingWebhook.getCalls().length,
+        2,
+        "5xx should be retried once",
       );
-      mocks.axios.post.resolves(Promise.reject(response));
-      try {
-        await send(mocks.core);
-      } catch (err) {
-        if (err instanceof SlackError) {
-          assert.ok(
-            err.message.includes("Request failed with status code 400"),
-          );
-        } else {
-          assert.fail(err);
-        }
-      }
-      assert.equal(mocks.axios.post.getCalls().length, 1);
-      const [url, payload, options] = mocks.axios.post.getCall(0).args;
-      assert.equal(url, "https://hooks.slack.com");
-      assert.deepEqual(payload, { textt: "oops" });
-      assert.deepEqual(options, {});
-      assert.equal(mocks.core.setOutput.getCall(0).firstArg, "ok");
-      assert.equal(mocks.core.setOutput.getCall(0).lastArg, false);
-      assert.equal(mocks.core.setOutput.getCall(1).firstArg, "response");
+      assert.equal(mocks.core.setOutput.getCall(0).lastArg, true);
     });
   });
 
   describe("proxies", () => {
-    it("requires a webhook is included in the inputs", async () => {
-      /**
-       * @type {Config}
-       */
-      const config = {
-        core: mocks.core,
-        inputs: {},
-      };
-      try {
-        new Webhook().proxies(config);
-        assert.fail("Failed to throw for missing input");
-      } catch (err) {
-        if (err instanceof SlackError) {
-          assert.ok(
-            err.message.includes("No webhook was provided to proxy to"),
-          );
-        } else {
-          assert.fail(err);
-        }
-      }
-    });
-
-    it("skips proxying an http webhook url altogether", async () => {
-      mocks.core.getInput.withArgs("webhook").returns("http://hooks.slack.com");
+    it("returns undefined when no proxy is set", async () => {
+      mocks.core.getInput
+        .withArgs("webhook")
+        .returns("https://hooks.slack.com");
       mocks.core.getInput.withArgs("webhook-type").returns("incoming-webhook");
-      mocks.core.getInput.withArgs("proxy").returns("https://example.com");
       const config = new Config(mocks.core);
       const webhook = new Webhook();
-      const request = webhook.proxies(config);
-      assert.strictEqual(request, undefined);
+      assert.strictEqual(webhook.proxies(config), undefined);
     });
 
     it("sets up the proxy agent for the provided https proxy", async () => {
@@ -204,23 +145,8 @@ describe("webhook", () => {
       mocks.core.getInput.withArgs("proxy").returns(proxy);
       const config = new Config(mocks.core);
       const webhook = new Webhook();
-      const { httpsAgent, proxy: proxying } = webhook.proxies(config);
+      const { httpsAgent } = webhook.proxies(config);
       assert.deepEqual(httpsAgent.proxy, new URL(proxy));
-      assert.notStrictEqual(proxying, false);
-    });
-
-    it("sets up the agent without proxy for http proxies", async () => {
-      const proxy = "http://example.com";
-      mocks.core.getInput
-        .withArgs("webhook")
-        .returns("https://hooks.slack.com");
-      mocks.core.getInput.withArgs("webhook-type").returns("incoming-webhook");
-      mocks.core.getInput.withArgs("proxy").returns(proxy);
-      const config = new Config(mocks.core);
-      const webhook = new Webhook();
-      const { httpsAgent, proxy: proxying } = webhook.proxies(config);
-      assert.deepEqual(httpsAgent.proxy, new URL(proxy));
-      assert.strictEqual(proxying, false);
     });
 
     it("fails to configure proxies with an invalid proxied url", async () => {
@@ -245,102 +171,33 @@ describe("webhook", () => {
         }
       }
     });
-
-    it("fails to configure proxies with an unknown url protocol", async () => {
-      const proxy = "ssh://";
-      mocks.core.getInput
-        .withArgs("webhook")
-        .returns("https://hooks.slack.com");
-      mocks.core.getInput.withArgs("webhook-type").returns("incoming-webhook");
-      mocks.core.getInput.withArgs("proxy").returns(proxy);
-      try {
-        const config = new Config(mocks.core);
-        const webhook = new Webhook();
-        webhook.proxies(config);
-        assert.fail("An unknown URL protocol was not thrown as error!");
-      } catch (err) {
-        if (err instanceof SlackError) {
-          assert.ok(
-            err.message.includes("Failed to configure the HTTPS proxy"),
-          );
-          assert.ok(err.cause.message.includes("Unsupported URL protocol"));
-        } else {
-          assert.fail(err);
-        }
-      }
-    });
   });
 
   describe("retries", () => {
-    it("uses a default of five retries in requests", async () => {
-      const webhook = new Webhook();
-      const result = webhook.retries();
+    it("uses a default of five retries", async () => {
+      const result = new Webhook().retries();
       assert.equal(result.retries, 5);
     });
 
     it('does not attempt retries when "0" is set', async () => {
-      const webhook = new Webhook();
-      const result = webhook.retries("0");
+      const result = new Webhook().retries("0");
       assert.equal(result.retries, 0);
     });
 
-    it('attempts a default amount of "5" retries', async () => {
-      const webhook = new Webhook();
-      const result = webhook.retries("5");
+    it('maps "5" to a five-retry policy', async () => {
+      const result = new Webhook().retries("5");
       assert.equal(result.retries, 5);
-      if (!result.retryDelay) {
-        assert.fail("No retry delay found!");
-      }
-      assert.equal(
-        result.retryDelay(5, mocks.errors.axios.network_failed),
-        300000,
-        "5th retry after 5 seconds",
-      );
     });
 
-    it('attempts "10" retries in around "30" minutes', async () => {
-      const webhook = new Webhook();
-      const result = webhook.retries("10");
+    it('maps "10" to a ten-retry policy', async () => {
+      const result = new Webhook().retries("10");
       assert.equal(result.retries, 10);
-      if (!result.retryDelay) {
-        assert.fail("No retry delay found!");
-      }
-      assert.ok(
-        result.retryDelay(10, mocks.errors.axios.network_failed) > 1800000,
-        "last attempt is around 30 minutes after starting",
-      );
-      assert.ok(
-        result.retryDelay(10, mocks.errors.axios.network_failed) < 3600000,
-        "last attempt is no more than an hour later",
-      );
     });
 
-    it('attempts a " rapid" burst of "12" retries in seconds', async () => {
-      const webhook = new Webhook();
-      const result = webhook.retries(" rapid");
-      assert.equal(result.retries, 12);
-      if (!result.retryDelay) {
-        assert.fail("No retry delay found!");
-      }
-      assert.equal(
-        result.retryDelay(12, mocks.errors.axios.network_failed),
-        12000,
-        "12th retry after 12 seconds",
-      );
-    });
-
-    it('attempts a "RAPID" burst of "12" retries in seconds', async () => {
-      const webhook = new Webhook();
-      const result = webhook.retries("RAPID");
-      assert.equal(result.retries, 12);
-      if (!result.retryDelay) {
-        assert.fail("No retry delay found!");
-      }
-      assert.equal(
-        result.retryDelay(12, mocks.errors.axios.network_failed),
-        12000,
-        "12th retry after 12 seconds",
-      );
+    it('maps "RAPID" (case/space-insensitive) to a rapid policy', async () => {
+      const rapid = new Webhook().retries("RAPID");
+      const spaced = new Webhook().retries(" rapid");
+      assert.deepEqual(rapid, spaced);
     });
   });
 });

--- a/test/webhook.spec.js
+++ b/test/webhook.spec.js
@@ -1,5 +1,6 @@
 import assert from "node:assert";
 import { beforeEach, describe, it } from "node:test";
+import webhook from "@slack/webhook";
 import Config from "../src/config.js";
 import SlackError from "../src/errors.js";
 import send from "../src/send.js";
@@ -230,34 +231,43 @@ describe("webhook", () => {
 
   describe("retries", () => {
     it("uses a default of five retries in requests", async () => {
-      const webhook = new Webhook();
-      const result = webhook.retries();
-      assert.equal(result.retries, 5);
+      const result = new Webhook().retries();
+      assert.equal(result.retries, webhook.fiveRetriesInFiveMinutes.retries);
     });
 
     it('does not attempt retries when "0" is set', async () => {
-      const webhook = new Webhook();
-      const result = webhook.retries("0");
+      const result = new Webhook().retries("0");
       assert.equal(result.retries, 0);
     });
 
     it('attempts a default amount of "5" retries', async () => {
-      const webhook = new Webhook();
-      const result = webhook.retries("5");
-      assert.equal(result.retries, 5);
+      const result = new Webhook().retries("5");
+      assert.equal(result.retries, webhook.fiveRetriesInFiveMinutes.retries);
+      assert.equal(result.factor, webhook.fiveRetriesInFiveMinutes.factor);
     });
 
     it('attempts "10" retries in around "30" minutes', async () => {
-      const webhook = new Webhook();
-      const result = webhook.retries("10");
-      assert.equal(result.retries, 10);
+      const result = new Webhook().retries("10");
+      assert.equal(
+        result.retries,
+        webhook.tenRetriesInAboutThirtyMinutes.retries,
+      );
+      assert.equal(
+        result.factor,
+        webhook.tenRetriesInAboutThirtyMinutes.factor,
+      );
     });
 
-    it('attempts a " rapid" burst of "RAPID" retries in seconds', async () => {
-      const webhook = new Webhook();
-      const rapid = webhook.retries("RAPID");
-      const spaced = webhook.retries(" rapid");
-      assert.deepEqual(rapid, spaced);
+    it('attempts a "rapid " burst of "12" retries in seconds', async () => {
+      const result = new Webhook().retries("rapid ");
+      assert.equal(result.retries, webhook.rapidRetryPolicy.retries);
+      assert.equal(result.factor, webhook.rapidRetryPolicy.factor);
+    });
+
+    it('attempts a "RAPID" burst of "12" retries in seconds', async () => {
+      const result = new Webhook().retries("RAPID");
+      assert.equal(result.retries, webhook.rapidRetryPolicy.retries);
+      assert.equal(result.factor, webhook.rapidRetryPolicy.factor);
     });
   });
 });

--- a/test/webhook.spec.js
+++ b/test/webhook.spec.js
@@ -161,6 +161,30 @@ describe("webhook", () => {
         }
       }
     });
+
+    it("fails to configure proxies with an unsupported protocol", async () => {
+      const proxy = "ftp://example.com";
+      mocks.core.getInput
+        .withArgs("webhook")
+        .returns("https://hooks.slack.com");
+      mocks.core.getInput.withArgs("webhook-type").returns("incoming-webhook");
+      mocks.core.getInput.withArgs("proxy").returns(proxy);
+      try {
+        const config = new Config(mocks.core);
+        const webhook = new Webhook();
+        webhook.proxies(config);
+        assert.fail("An unsupported proxy protocol was not thrown as error!");
+      } catch (err) {
+        if (err instanceof SlackError) {
+          assert.ok(
+            err.message.includes("Failed to configure the HTTPS proxy"),
+          );
+          assert.ok(err.cause?.message?.includes("Unsupported URL protocol"));
+        } else {
+          assert.fail(err);
+        }
+      }
+    });
   });
 
   describe("retries", () => {

--- a/test/webhook.spec.js
+++ b/test/webhook.spec.js
@@ -87,6 +87,32 @@ describe("webhook", () => {
       }
     });
 
+    it("errors when an unknown webhook type is provided", async () => {
+      /**
+       * @type {Config}
+       */
+      const config = {
+        core: mocks.core,
+        inputs: {
+          webhook: "https://hooks.slack.com",
+          webhookType: "unknown-webhook",
+          retries: "5",
+        },
+      };
+      try {
+        await new Webhook().post(config);
+        assert.fail("Failed to throw for an unknown webhook type");
+      } catch (err) {
+        if (err instanceof SlackError) {
+          assert.ok(
+            err.message.includes("Unknown webhook type: unknown-webhook"),
+          );
+        } else {
+          assert.fail(err);
+        }
+      }
+    });
+
     it("returns the failures from a webhook trigger", async () => {
       mocks.core.getBooleanInput.withArgs("errors").returns(true);
       mocks.core.getInput
@@ -182,6 +208,19 @@ describe("webhook", () => {
 
     it("sets up the proxy agent for the provided https proxy", async () => {
       const proxy = "https://example.com";
+      mocks.core.getInput
+        .withArgs("webhook")
+        .returns("https://hooks.slack.com");
+      mocks.core.getInput.withArgs("webhook-type").returns("incoming-webhook");
+      mocks.core.getInput.withArgs("proxy").returns(proxy);
+      const config = new Config(mocks.core);
+      const webhook = new Webhook();
+      const httpsAgent = webhook.proxies(config);
+      assert.deepEqual(httpsAgent.proxy, new URL(proxy));
+    });
+
+    it("sets up the proxy agent for the provided http proxy", async () => {
+      const proxy = "http://example.com";
       mocks.core.getInput
         .withArgs("webhook")
         .returns("https://hooks.slack.com");

--- a/test/webhook.spec.js
+++ b/test/webhook.spec.js
@@ -229,7 +229,7 @@ describe("webhook", () => {
   });
 
   describe("retries", () => {
-    it("uses a default of five retries", async () => {
+    it("uses a default of five retries in requests", async () => {
       const webhook = new Webhook();
       const result = webhook.retries();
       assert.equal(result.retries, 5);
@@ -241,19 +241,19 @@ describe("webhook", () => {
       assert.equal(result.retries, 0);
     });
 
-    it('maps "5" to a five-retry policy', async () => {
+    it('attempts a default amount of "5" retries', async () => {
       const webhook = new Webhook();
       const result = webhook.retries("5");
       assert.equal(result.retries, 5);
     });
 
-    it('maps "10" to a ten-retry policy', async () => {
+    it('attempts "10" retries in around "30" minutes', async () => {
       const webhook = new Webhook();
       const result = webhook.retries("10");
       assert.equal(result.retries, 10);
     });
 
-    it('maps "RAPID" (case/space-insensitive) to a rapid policy', async () => {
+    it('attempts a " rapid" burst of "RAPID" retries in seconds', async () => {
       const webhook = new Webhook();
       const rapid = webhook.retries("RAPID");
       const spaced = webhook.retries(" rapid");

--- a/test/webhook.spec.js
+++ b/test/webhook.spec.js
@@ -101,7 +101,7 @@ describe("webhook", () => {
       };
       try {
         await new Webhook().post(config);
-        assert.fail("Failed to throw for an unknown webhook type");
+        assert.fail();
       } catch (err) {
         if (err instanceof SlackError) {
           assert.ok(

--- a/test/webhook.spec.js
+++ b/test/webhook.spec.js
@@ -203,8 +203,8 @@ describe("webhook", () => {
       }
     });
 
-    it("fails to configure proxies with an unsupported protocol", async () => {
-      const proxy = "ftp://example.com";
+    it("fails to configure proxies with an unknown url protocol", async () => {
+      const proxy = "ssh://";
       mocks.core.getInput
         .withArgs("webhook")
         .returns("https://hooks.slack.com");
@@ -214,7 +214,7 @@ describe("webhook", () => {
         const config = new Config(mocks.core);
         const webhook = new Webhook();
         webhook.proxies(config);
-        assert.fail("An unsupported proxy protocol was not thrown as error!");
+        assert.fail("An unknown URL protocol was not thrown as error!");
       } catch (err) {
         if (err instanceof SlackError) {
           assert.ok(

--- a/test/webhook.spec.js
+++ b/test/webhook.spec.js
@@ -139,6 +139,15 @@ describe("webhook", () => {
       assert.deepEqual(httpsAgent.proxy, new URL(proxy));
     });
 
+    it("skips the proxy when the webhook destination is not HTTPS", async () => {
+      mocks.core.getInput.withArgs("webhook").returns("http://hooks.slack.com");
+      mocks.core.getInput.withArgs("webhook-type").returns("incoming-webhook");
+      mocks.core.getInput.withArgs("proxy").returns("https://example.com");
+      const config = new Config(mocks.core);
+      const webhook = new Webhook();
+      assert.strictEqual(webhook.proxies(config), undefined);
+    });
+
     it("fails to configure proxies with an invalid proxied url", async () => {
       const proxy = "https://";
       mocks.core.getInput

--- a/test/webhook.spec.js
+++ b/test/webhook.spec.js
@@ -99,7 +99,7 @@ describe("webhook", () => {
       );
       try {
         await send(mocks.core);
-        assert.fail("A webhook trigger failure was not thrown as error!");
+        assert.fail();
       } catch (err) {
         if (err instanceof SlackError) {
           assert.ok(err.message.includes("An HTTP protocol error occurred"));
@@ -125,7 +125,7 @@ describe("webhook", () => {
       );
       try {
         await send(mocks.core);
-        assert.fail("An incoming webhook failure was not thrown as error!");
+        assert.fail();
       } catch (err) {
         if (err instanceof SlackError) {
           assert.ok(err.message.includes("An HTTP protocol error occurred"));

--- a/test/webhook.spec.js
+++ b/test/webhook.spec.js
@@ -258,8 +258,8 @@ describe("webhook", () => {
       );
     });
 
-    it('attempts a "rapid " burst of "12" retries in seconds', async () => {
-      const result = new Webhook().retries("rapid ");
+    it('attempts a " rapid" burst of "12" retries in seconds', async () => {
+      const result = new Webhook().retries(" rapid");
       assert.equal(result.retries, webhook.rapidRetryPolicy.retries);
       assert.equal(result.factor, webhook.rapidRetryPolicy.factor);
     });

--- a/test/webhook.spec.js
+++ b/test/webhook.spec.js
@@ -76,52 +76,42 @@ describe("webhook", () => {
       }
     });
 
-    it("does not retry a 4xx from a webhook trigger", async () => {
+    it("returns the failures from a webhook trigger", async () => {
       mocks.core.getInput
         .withArgs("webhook")
         .returns("https://hooks.slack.com");
       mocks.core.getInput.withArgs("webhook-type").returns("webhook-trigger");
       mocks.core.getInput.withArgs("payload").returns("drinks: coffee");
-      mocks.core.getInput.withArgs("retries").returns("RAPID");
-      const err = Object.assign(new Error("An HTTP protocol error occurred"), {
-        code: "slack_webhook_http_error",
-        original: { response: { status: 400 } },
-      });
-      mocks.webhookTrigger.rejects(err);
+      mocks.webhookTrigger.rejects(
+        new Error("An HTTP protocol error occurred"),
+      );
       try {
         await send(mocks.core);
       } catch (e) {
         assert.ok(e instanceof SlackError);
       }
-      assert.equal(
-        mocks.webhookTrigger.getCalls().length,
-        1,
-        "4xx must not be retried",
-      );
+      assert.equal(mocks.webhookTrigger.getCalls().length, 1);
       assert.equal(mocks.core.setOutput.getCall(0).firstArg, "ok");
       assert.equal(mocks.core.setOutput.getCall(0).lastArg, false);
     });
 
-    it("retries a 5xx from an incoming webhook then succeeds", async () => {
+    it("returns the failures from an incoming webhook", async () => {
       mocks.core.getInput
         .withArgs("webhook")
         .returns("https://hooks.slack.com");
       mocks.core.getInput.withArgs("webhook-type").returns("incoming-webhook");
       mocks.core.getInput.withArgs("payload").returns("text: hi");
-      mocks.core.getInput.withArgs("retries").returns("RAPID");
-      const err = Object.assign(new Error("An HTTP protocol error occurred"), {
-        code: "slack_webhook_http_error",
-        original: { response: { status: 503 } },
-      });
-      mocks.incomingWebhook.onFirstCall().rejects(err);
-      mocks.incomingWebhook.onSecondCall().resolves({ text: "ok" });
-      await send(mocks.core);
-      assert.equal(
-        mocks.incomingWebhook.getCalls().length,
-        2,
-        "5xx should be retried once",
+      mocks.incomingWebhook.rejects(
+        new Error("An HTTP protocol error occurred"),
       );
-      assert.equal(mocks.core.setOutput.getCall(0).lastArg, true);
+      try {
+        await send(mocks.core);
+      } catch (e) {
+        assert.ok(e instanceof SlackError);
+      }
+      assert.equal(mocks.incomingWebhook.getCalls().length, 1);
+      assert.equal(mocks.core.setOutput.getCall(0).firstArg, "ok");
+      assert.equal(mocks.core.setOutput.getCall(0).lastArg, false);
     });
   });
 

--- a/test/webhook.spec.js
+++ b/test/webhook.spec.js
@@ -123,7 +123,7 @@ describe("webhook", () => {
         .withArgs("webhook")
         .returns("https://hooks.slack.com");
       mocks.core.getInput.withArgs("webhook-type").returns("incoming-webhook");
-      mocks.core.getInput.withArgs("payload").returns("text: hi");
+      mocks.core.getInput.withArgs("payload").returns("textt: oops");
       mocks.webhook.incoming.rejects(
         new Error("An HTTP protocol error occurred"),
       );
@@ -139,7 +139,7 @@ describe("webhook", () => {
       }
       assert.equal(mocks.webhook.incoming.getCalls().length, 1);
       assert.deepEqual(mocks.webhook.incoming.getCall(0).firstArg, {
-        text: "hi",
+        textt: "oops",
       });
       assert.ok(mocks.core.setFailed.called);
       assert.equal(mocks.core.setOutput.getCall(0).firstArg, "ok");

--- a/test/webhook.spec.js
+++ b/test/webhook.spec.js
@@ -171,6 +171,15 @@ describe("webhook", () => {
       }
     });
 
+    it("skips proxying an http webhook url altogether", async () => {
+      mocks.core.getInput.withArgs("webhook").returns("http://hooks.slack.com");
+      mocks.core.getInput.withArgs("webhook-type").returns("incoming-webhook");
+      mocks.core.getInput.withArgs("proxy").returns("https://example.com");
+      const config = new Config(mocks.core);
+      const webhook = new Webhook();
+      assert.strictEqual(webhook.proxies(config), undefined);
+    });
+
     it("returns undefined when no proxy is set", async () => {
       mocks.core.getInput
         .withArgs("webhook")
@@ -192,15 +201,6 @@ describe("webhook", () => {
       const webhook = new Webhook();
       const httpsAgent = webhook.proxies(config);
       assert.deepEqual(httpsAgent.proxy, new URL(proxy));
-    });
-
-    it("skips the proxy when the webhook destination is not HTTPS", async () => {
-      mocks.core.getInput.withArgs("webhook").returns("http://hooks.slack.com");
-      mocks.core.getInput.withArgs("webhook-type").returns("incoming-webhook");
-      mocks.core.getInput.withArgs("proxy").returns("https://example.com");
-      const config = new Config(mocks.core);
-      const webhook = new Webhook();
-      assert.strictEqual(webhook.proxies(config), undefined);
     });
 
     it("fails to configure proxies with an invalid proxied url", async () => {

--- a/test/webhook.spec.js
+++ b/test/webhook.spec.js
@@ -108,9 +108,13 @@ describe("webhook", () => {
         }
       }
       assert.equal(mocks.webhook.trigger.getCalls().length, 1);
+      assert.deepEqual(mocks.webhook.trigger.getCall(0).firstArg, {
+        drinks: "coffee",
+      });
       assert.ok(mocks.core.setFailed.called);
       assert.equal(mocks.core.setOutput.getCall(0).firstArg, "ok");
       assert.equal(mocks.core.setOutput.getCall(0).lastArg, false);
+      assert.equal(mocks.core.setOutput.getCall(1).firstArg, "response");
     });
 
     it("returns the failures from an incoming webhook", async () => {
@@ -134,9 +138,13 @@ describe("webhook", () => {
         }
       }
       assert.equal(mocks.webhook.incoming.getCalls().length, 1);
+      assert.deepEqual(mocks.webhook.incoming.getCall(0).firstArg, {
+        text: "hi",
+      });
       assert.ok(mocks.core.setFailed.called);
       assert.equal(mocks.core.setOutput.getCall(0).firstArg, "ok");
       assert.equal(mocks.core.setOutput.getCall(0).lastArg, false);
+      assert.equal(mocks.core.setOutput.getCall(1).firstArg, "response");
     });
   });
 


### PR DESCRIPTION
### Summary

Converts both webhook techniques to the [`@slack/webhook`](https://docs.slack.dev/tools/node-slack-sdk/webhook/) SDK and removes `axios` / `axios-retry` as **direct** dependencies of the action:

- `incoming-webhook` → `IncomingWebhook` class
- `webhook-trigger` → `WebhookTrigger` class

Retry behavior (`0` / `5` / `10` / `RAPID`) and HTTPS proxy support are preserved, so this is not a regression. Retries are handled inside the SDK: the selected policy is passed as the `retryConfig` option to the `IncomingWebhook` / `WebhookTrigger` client, using `@slack/webhook`'s own `retryPolicies` (`fiveRetriesInFiveMinutes`, `tenRetriesInAboutThirtyMinutes`, `rapidRetryPolicy`), with `fiveRetriesInFiveMinutes` as the default. The action no longer runs its own `p-retry` loop.

`src/config.js` no longer owns an axios client or builds the webhook `User-Agent` — the SDKs set their own. The action still registers app metadata with `@slack/web-api`.

#### Notes

- `@slack/webhook` is pinned to the published `^7.2.0` release (which exports `WebhookTrigger`).
- A patch changeset is included, so this releases as `3.0.4`.
- No `@slack/web-api` version bump in this PR; `client.js` (the API-method technique) is unchanged and still uses `@slack/web-api@7` (axios transitively).
- `dist/` is rebuilt as part of release, not committed here.

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)