### PR TITLE
fix: revert multiline yaml parsing indentation change

### DIFF
--- a/.changeset/revert-js-yaml-4x.md
+++ b/.changeset/revert-js-yaml-4x.md
@@ -1,0 +1,5 @@
+---
+"@slack/slack-github-action": patch
+---
+
+fix: revert multiline yaml parsing indentation change

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -103,6 +103,24 @@ jobs:
         env:
           MESSAGE_OUTPUT_TS: ${{ steps.message.outputs.ts }}
 
+      - name: "test(api): post a multiline message"
+        id: multiline
+        uses: ./
+        with:
+          errors: true
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            text: ":checkered_flag: A multiline message wraps across lines
+
+            with a blank line before <https://github.com/${{ github.repository }}|a link>"
+
+      - name: "test(api): confirm the multiline message was posted"
+        run: test -n "$MULTILINE_OUTPUT_TS"
+        env:
+          MULTILINE_OUTPUT_TS: ${{ steps.multiline.outputs.ts }}
+
       - name: "test(api): post a message with blocks"
         id: blocks
         uses: ./

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -103,7 +103,7 @@ jobs:
         env:
           MESSAGE_OUTPUT_TS: ${{ steps.message.outputs.ts }}
 
-      - name: "test(api): post a multiline message"
+      - name: "test(api): post a multiline message" # https://github.com/slackapi/slack-github-action/issues/637
         id: multiline
         uses: ./
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,13 +16,14 @@
         "@slack/webhook": "^7.2.0",
         "flat": "^6.0.1",
         "https-proxy-agent": "^9.0.0",
-        "js-yaml": "^5.2.0",
+        "js-yaml": "^4.2.0",
         "markup-js": "^1.5.21"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.5.1",
         "@changesets/cli": "^2.31.0",
         "@types/flat": "^5.0.5",
+        "@types/js-yaml": "^4.0.9",
         "@types/markup-js": "^1.5.0",
         "@types/node": "^24.13.2",
         "@types/sinon": "^21.0.0",
@@ -460,29 +461,6 @@
       "dependencies": {
         "@changesets/types": "^6.1.0",
         "js-yaml": "^4.1.1"
-      }
-    },
-    "node_modules/@changesets/parse/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@changesets/pre": {
@@ -940,6 +918,13 @@
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/@types/flat/-/flat-5.0.5.tgz",
       "integrity": "sha512-nPLljZQKSnac53KDUDzuzdRfGI0TDb5qPrb+SrQyN3MtdQrOnGsKniHN1iYZsJEBIVQve94Y6gNz22sgISZq+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1701,9 +1686,9 @@
       "license": "ISC"
     },
     "node_modules/js-yaml": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.0.tgz",
-      "integrity": "sha512-YeLUMlvR4Ou1B119LIaM0r65JvbOBooJDc9yEu0dClb/uSC5P4FrLU8OCCz/HXWvtPoIrR0dRzABTjo1sTN9Bw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",
@@ -1719,7 +1704,7 @@
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.mjs"
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/jsonfile": {

--- a/package.json
+++ b/package.json
@@ -49,13 +49,14 @@
     "@slack/webhook": "^7.2.0",
     "flat": "^6.0.1",
     "https-proxy-agent": "^9.0.0",
-    "js-yaml": "^5.2.0",
+    "js-yaml": "^4.2.0",
     "markup-js": "^1.5.21"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.1",
     "@changesets/cli": "^2.31.0",
     "@types/flat": "^5.0.5",
+    "@types/js-yaml": "^4.0.9",
     "@types/markup-js": "^1.5.0",
     "@types/node": "^24.13.2",
     "@types/sinon": "^21.0.0",

--- a/test/content.spec.js
+++ b/test/content.spec.js
@@ -74,7 +74,7 @@ describe("content", () => {
     /**
      * @see {@link https://github.com/slackapi/slack-github-action/issues/637}
      */
-    it("parses multiline YAML strings from the input payload", async () => {
+    it("parses multiline YAML from the input payload", async () => {
       mocks.core.getInput
         .withArgs("payload")
         .returns('channel: C0123456789\ntext: "first line\n\nsecond line"');

--- a/test/content.spec.js
+++ b/test/content.spec.js
@@ -71,6 +71,21 @@ describe("content", () => {
       assert.deepEqual(config.content.values, expected);
     });
 
+    /**
+     * @see {@link https://github.com/slackapi/slack-github-action/issues/637}
+     */
+    it("parses multiline YAML strings from the input payload", async () => {
+      mocks.core.getInput
+        .withArgs("payload")
+        .returns('channel: C0123456789\ntext: "first line\n\nsecond line"');
+      const config = new Config(mocks.core);
+      const expected = {
+        channel: "C0123456789",
+        text: "first line\nsecond line",
+      };
+      assert.deepEqual(config.content.values, expected);
+    });
+
     it("parses complete JSON from the input payload", async () => {
       mocks.core.getInput.withArgs("payload").returns(`{
           "message": "this is wrapped",


### PR DESCRIPTION
### Summary

This pull request reverts `js-yaml` to `4.x` to restore parsing of multiline payload strings, fixing a v3.0.4 regression.

- js-yaml `5.x` (bumped in #635) enforces strict YAML 1.2 flow-scalar indentation and throws `deficient indentation` when a double-quoted value wraps across a blank line onto a column-0 continuation.
- A `payload: |` block strips its common indent, so keys and wrapped values land at column 0 — the exact shape of a multi-paragraph Slack message. Payloads that worked in v3.0.3 broke in v3.0.4.
- No `5.x` schema or option relaxes this (`CORE_SCHEMA`, `YAML11_SCHEMA`, and the default all throw identically), so this reverts `js-yaml` to `^4.2.0` and restores the `@types/js-yaml` devDependency.
- Adds a unit regression test and a multiline-payload step in the integration workflow, both of which previously lacked coverage for this shape.

The first commit adds the failing regression test with production code unchanged (fails on `5.x`); a later commit lands the revert that turns it green.

Fixes #637

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).