### PR TITLE
chore: track undici-types to the resolved undici version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    groups:
-      undici:
-        patterns:
-          - "undici"
-          - "undici-types"
     ignore:
       - dependency-name: "@types/node"
         versions:

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "undici": "^7.28.0"
   },
   "overrides": {
-    "undici-types": "^7.28.0"
+    "undici-types": "$undici"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.4",


### PR DESCRIPTION
### Summary

This pull request makes `undici-types` follow `undici` automatically and removes the now-redundant Dependabot group.

- The `overrides` block pinned `undici-types` to `^7.28.0` while `undici` is a direct dependency that Dependabot bumps independently (e.g. #648 moves `undici` to 8.x). Because `undici-types` is pulled in transitively by `@types/node`, the runtime library and its type declarations could drift apart on a major bump.
- Using the `"$undici"` override resolves `undici-types` to whatever version `undici` resolves to, keeping them in lockstep automatically on every future bump.
- With the override handling lockstep, the Dependabot `undici` group (which existed to bump `undici` + `undici-types` together) is redundant, so it is removed. `undici` bumps now arrive as normal ungrouped PRs and the types follow via the override.
- Minimal change: `$undici` resolves to `7.28.0` today (same as the old pin), so the lockfile is unchanged; the new behavior activates when `undici` bumps.

### Testing

- Simulate a future undici bump locally: set `undici` to `^8.7.0`, run `npm install`, and confirm `npm ls undici undici-types` shows both resolving to `8.7.0` (the override tracks undici to 8.x, overriding `@types/node`'s declared `~7.18.0`).

### Requirements <!-- Place an \`x\` in each \`[ ]\` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-github-action/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)